### PR TITLE
fix(skills): write disposable scratch to the current repo .tmp

### DIFF
--- a/.agents/memory/architecture.md
+++ b/.agents/memory/architecture.md
@@ -13,6 +13,7 @@ last_verified: 2026-07-13
 | `.codex/` | Codex loader adapters for shared maintenance content | Tracked |
 | `.github/` | Issue templates and GitHub Actions workflows | Tracked |
 | `.husky/` | Git hook configuration | Tracked |
+| `.tmp/` | Tracked repository content | Tracked |
 | `assets/` | Static repository assets | Tracked |
 | `bundles/` | Generated marketplace bundle snapshots | 13 generated bundles |
 | `commands/` | Claude Code/plugin command adapters | 32 command adapters |

--- a/.agents/memory/system/skill-standards.md
+++ b/.agents/memory/system/skill-standards.md
@@ -84,6 +84,21 @@ skills/my-skill/
 
 Keep `SKILL.md` focused: under 500 lines. Move anything detailed to `references/`.
 
+## Scratch files
+
+Disposable process files belong in the **current repository's** `.tmp/`
+directory, not `/tmp` or `/private/tmp`.
+
+```bash
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+# write "$REPO_TMP/snapshot.json", "$REPO_TMP/body.md", …
+```
+
+Worktrees stay at `<repo>/.worktrees/<name>`. Durable non-repo artifacts stay
+under `~/.codex/artifacts/`. Never write helper scripts, PR snapshots, issue
+bodies, or logs to the machine-wide temp directory.
+
 Keep references **one level deep**: `SKILL.md` may point at files in `references/`, but those files must not chain on to further files (no A→B→C). Progressive disclosure breaks down when Claude has to follow a trail.
 
 ## Contract blocks for composable skills

--- a/.agents/skills/skill-auditor/SKILL.md
+++ b/.agents/skills/skill-auditor/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Run periodically or before releases.
 metadata:
   internal: true
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "audit, skills, quality, maintenance"
 ---
 
@@ -72,15 +72,17 @@ per-skill link table):
 
 ```bash
 # Get skills from filesystem
-find skills -maxdepth 1 -mindepth 1 -type d | sed 's|skills/||' | sort > /tmp/fs-skills.txt
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+find skills -maxdepth 1 -mindepth 1 -type d | sed 's|skills/||' | sort > "$REPO_TMP/fs-skills.txt"
 
 # Get skills from the README's categorized lists
 sed -n '/^## Skills (/,/^## How Skills Adapt/p' README.md \
-  | grep -oE '`[a-z0-9-]+`' | tr -d '`' | sort -u > /tmp/readme-skills.txt
+  | grep -oE '`[a-z0-9-]+`' | tr -d '`' | sort -u > "$REPO_TMP/readme-skills.txt"
 
 # Diff
-comm -23 /tmp/fs-skills.txt /tmp/readme-skills.txt  # in fs, not README
-comm -13 /tmp/fs-skills.txt /tmp/readme-skills.txt  # in README, not fs
+comm -23 "$REPO_TMP/fs-skills.txt" "$REPO_TMP/readme-skills.txt"  # in fs, not README
+comm -13 "$REPO_TMP/fs-skills.txt" "$REPO_TMP/readme-skills.txt"  # in README, not fs
 ```
 
 Also verify each category heading's `(N)` count matches the number of names in

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -182,7 +182,7 @@
     {
       "name": "bug",
       "source": "./skills/bug",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "File a GitHub issue of type Bug from a description — structures a clear bug report (summary, steps to reproduce, expected vs actual, environment), previews it, then on confirmation creates the issue with the Bug issue type (falling back to a bug label when the repo has no issue types). Use when the user asks to file a bug, open a bug report, create a GitHub bug issue, log a bug, or runs /bug."
     },
     {
@@ -230,7 +230,7 @@
     {
       "name": "codex-image-gen",
       "source": "./skills/codex-image-gen",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Generate raster images (icons, illustrations, textures, app icons) from a text prompt by driving the Codex CLI's image tool, then extracting the finished PNG from the Codex session rollout. Use when an agent needs a real generated image and has no native image-generation tool. Requires the `codex` CLI, logged in."
     },
     {
@@ -368,7 +368,7 @@
     {
       "name": "ec2-backend-deployer",
       "source": "./skills/ec2-backend-deployer",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Deploys backend applications to EC2 instances using Docker, GitHub Actions CI/CD, and Tailscale for secure SSH access. Activates when setting up EC2 deployment pipelines, configuring container registries, or wiring automated deploys for NestJS, Next.js, or Express backends."
     },
     {
@@ -404,7 +404,7 @@
     {
       "name": "feature-intake",
       "source": "./skills/feature-intake",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "description": "Capture a client or stakeholder feature request, turn it into a planner-ready PRD epic with scoped sub-issues, check for duplicate work, and place approved issues on a GitHub Projects kanban. Use when a user invokes feature intake, asks to turn a rough client requirement into GitHub issues, or wants an idea written as a PRD and pushed to a board."
     },
     {
@@ -470,7 +470,7 @@
     {
       "name": "gh-review-suggestions",
       "source": "./skills/gh-review-suggestions",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Review GitHub pull requests and post precise inline suggested changes with GitHub suggestion blocks. Use when asked to review a PR, leave actionable GitHub comments, propose applyable fixes, or submit review suggestions through gh."
     },
     {
@@ -500,7 +500,7 @@
     {
       "name": "grok-review",
       "source": "./skills/grok-review",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Independent second-opinion code review through the Grok CLI. Builds a self-contained review prompt from the exact diff, runs one headless Grok invocation on the CLI's own default model and effort, then verifies every returned finding against the code before reporting. Use when asked to review with Grok, get a second opinion on a branch, worktree, or PR from another CLI, or cross-check a review with an independent engine."
     },
     {
@@ -572,7 +572,7 @@
     {
       "name": "merge-open-prs",
       "source": "./skills/merge-open-prs",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "description": "Review and land open pull requests through one /merge command. The default mode runs a confirmation-gated trunk sweep and cleanup; exact /merge force drains the queue non-serially by merging green PRs and narrowly fixing red PRs. Use when asked to review and merge open PRs, batch-merge to trunk, drain PR WIP, or run /merge."
     },
     {
@@ -638,7 +638,7 @@
     {
       "name": "open-source-checker",
       "source": "./skills/open-source-checker",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Audits a whole private repository once, at the decision to make it public. Runs four passes — license and attribution, secrets across the entire git history, private references (internal hostnames, employee emails, client and customer names, staging URLs), and publication readiness — then returns a publish or block verdict. Use when the user is preparing to open source a repository, asks whether a codebase is safe to publish, wants a pre-release audit before flipping a repo public, or needs to know what is still private in code that is about to ship publicly."
     },
     {
@@ -818,7 +818,7 @@
     {
       "name": "release-cleanup",
       "source": "./skills/release-cleanup",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "description": "Verify a release branch is provably merged into the trunk (default branch) via the squash-aware GitHub PR merge oracle, then prune merged local and remote feature branches and stale git worktrees. Squash-merge aware — uses GitHub PR merge state as the merge oracle, not commit ancestry. Use when the user asks to clean up branches after a deploy, prune worktrees, remove merged branches, or confirm nothing stale was left behind before pruning."
     },
     {
@@ -836,7 +836,7 @@
     {
       "name": "review-dispatch",
       "source": "./skills/review-dispatch",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "description": "Single front door for code review. Resolves a target — working-tree changes, one PR, all open PRs, the last N commits, a time window, or a retrospective over merged history — into the right workflow, natively or through an external second-opinion engine (grok). Keeps every /review mode report-only except confirmation-gated retrospective issue filing. Backs the /review command. Use when asked to review changes, a PR, all PRs, recent commits, or merged history, or to get a second opinion from another CLI."
     },
     {
@@ -878,7 +878,7 @@
     {
       "name": "setup-agent-routing",
       "source": "./skills/setup-agent-routing",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "description": "Sets up an `## Agent skills` routing block in CLAUDE.md/AGENTS.md plus docs/agents/ so the dev-loop skills (executing-plans, feature-intake, prd-writer, qa-reviewer) know this repo's GitHub issue tracker, kanban label vocabulary, and domain doc layout. Run once per repo before first use of the loop, or when those skills appear to lack tracker, label, or domain context."
     },
     {

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 node_modules/
 
+# Agent/process scratch for this checkout. Never /tmp or /private/tmp.
+.tmp/*
+!.tmp/.gitkeep
+
 # Generated marketplace output
 plugins/
 

--- a/.tmp/.gitkeep
+++ b/.tmp/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this directory in clones. Scratch files stay untracked.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Skills are **model-agnostic playbooks**: the harness supplies the model, so no s
 | `.codex/` | Codex loader adapters for shared maintenance content | Tracked |
 | `.github/` | Issue templates and GitHub Actions workflows | Tracked |
 | `.husky/` | Git hook configuration | Tracked |
+| `.tmp/` | Tracked repository content | Tracked |
 | `assets/` | Static repository assets | Tracked |
 | `bundles/` | Generated marketplace bundle snapshots | 13 generated bundles |
 | `commands/` | Claude Code/plugin command adapters | 32 command adapters |

--- a/bundles/ai-agents/skills/codex-image-gen/SKILL.md
+++ b/bundles/ai-agents/skills/codex-image-gen/SKILL.md
@@ -5,7 +5,7 @@ description: >-
 license: MIT
 compatibility: Requires the `codex` CLI (logged in) plus `python3` and `base64`; `sips` is optional for post-processing on macOS.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "codex, image-generation, gpt-image, cli, assets, app-icon"
 when_to_use: "generate an image, make an icon, create an app icon, render an illustration or texture, agent needs an image but has no image tool, codex image generation"
 ---
@@ -52,7 +52,9 @@ model has no other context:
 - Target aspect ratio and rough size.
 
 ```bash
-cat > /tmp/img-prompt.txt <<'PROMPT'
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+cat > "$REPO_TMP/img-prompt.txt" <<'PROMPT'
 A single app icon: a glossy translucent envelope on a soft blue-to-violet
 gradient, Liquid Glass style, centered with even padding, no text, no letters,
 1:1 square, high detail.
@@ -62,7 +64,7 @@ PROMPT
 ### 2. Run `codex exec` and capture stdout
 
 ```bash
-codex exec -s read-only "$(cat /tmp/img-prompt.txt)" 2>&1 | tee /tmp/codex-run.log
+codex exec -s read-only "$(cat "$REPO_TMP/img-prompt.txt")" 2>&1 | tee "$REPO_TMP/codex-run.log"
 ```
 
 Run it in the **foreground**. `exec` returns once the turn completes; in practice
@@ -73,7 +75,7 @@ the `result` is already written to the rollout by then.
 Codex prints a `session id: <uuid>` line. Pull it from the captured log:
 
 ```bash
-SESSION_ID=$(grep -oE 'session id: [0-9a-f-]{36}' /tmp/codex-run.log | awk '{print $3}')
+SESSION_ID=$(grep -oE 'session id: [0-9a-f-]{36}' "$REPO_TMP/codex-run.log" | awk '{print $3}')
 echo "session: $SESSION_ID"
 ```
 
@@ -84,7 +86,7 @@ Walk it, find the largest `result` string (the base64 image), and decode it. Use
 the bundled helper:
 
 ```bash
-python3 scripts/extract-codex-image.py "$SESSION_ID" /tmp/out.png
+python3 scripts/extract-codex-image.py "$SESSION_ID" "$REPO_TMP/out.png"
 ```
 
 ### 5. Assert success
@@ -92,7 +94,7 @@ python3 scripts/extract-codex-image.py "$SESSION_ID" /tmp/out.png
 Confirm the file exists and is a real PNG before using it:
 
 ```bash
-test -s /tmp/out.png && file /tmp/out.png   # expect: PNG image data, 1254 x 1254
+test -s "$REPO_TMP/out.png" && file "$REPO_TMP/out.png"   # expect: PNG image data, 1254 x 1254
 ```
 
 If extraction finds no base64 `result`, the turn did not actually generate an
@@ -105,8 +107,8 @@ Default output is roughly **1254×1254 PNG, RGB, no alpha**. Resize / strip alph
 with `sips` on macOS:
 
 ```bash
-sips -z 1024 1024 /tmp/out.png --out /tmp/icon-1024.png   # downscale
-sips -s format png /tmp/out.png --out /tmp/flat.png        # normalize
+sips -z 1024 1024 "$REPO_TMP/out.png" --out "$REPO_TMP/icon-1024.png"   # downscale
+sips -s format png "$REPO_TMP/out.png" --out "$REPO_TMP/flat.png"        # normalize
 ```
 
 ## Reference extractor
@@ -152,27 +154,29 @@ print("WROTE", out)
 ## Worked example: build a macOS/iOS app icon set
 
 ```bash
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
 # 1. Generate a 1:1 icon master.
-cat > /tmp/icon-prompt.txt <<'PROMPT'
+cat > "$REPO_TMP/icon-prompt.txt" <<'PROMPT'
 App icon: a glossy translucent envelope, Liquid Glass style, soft blue-to-violet
 gradient background, centered, even padding, no text, no letters, 1:1 square.
 PROMPT
-codex exec -s read-only "$(cat /tmp/icon-prompt.txt)" 2>&1 | tee /tmp/codex-run.log
-SESSION_ID=$(grep -oE 'session id: [0-9a-f-]{36}' /tmp/codex-run.log | awk '{print $3}')
-python3 scripts/extract-codex-image.py "$SESSION_ID" /tmp/icon-master.png
+codex exec -s read-only "$(cat "$REPO_TMP/icon-prompt.txt")" 2>&1 | tee "$REPO_TMP/codex-run.log"
+SESSION_ID=$(grep -oE 'session id: [0-9a-f-]{36}' "$REPO_TMP/codex-run.log" | awk '{print $3}')
+python3 scripts/extract-codex-image.py "$SESSION_ID" "$REPO_TMP/icon-master.png"
 
 # 2. Make a 1024 master with no alpha (iOS rejects alpha on the marketing icon).
-sips -z 1024 1024 /tmp/icon-master.png --out /tmp/AppIcon-1024.png
-sips -s format png --setProperty hasAlpha false /tmp/AppIcon-1024.png --out /tmp/AppIcon-1024.png
+sips -z 1024 1024 "$REPO_TMP/icon-master.png" --out "$REPO_TMP/AppIcon-1024.png"
+sips -s format png --setProperty hasAlpha false "$REPO_TMP/AppIcon-1024.png" --out "$REPO_TMP/AppIcon-1024.png"
 
 # 3. Slice into an AppIcon.appiconset (iOS single-size 1024 + the macOS ladder).
 mkdir -p AppIcon.appiconset
-cp /tmp/AppIcon-1024.png AppIcon.appiconset/icon_1024.png
+cp "$REPO_TMP/AppIcon-1024.png" AppIcon.appiconset/icon_1024.png
 for sz in 16 32 64 128 256 512 1024; do
-  sips -z "$sz" "$sz" /tmp/AppIcon-1024.png --out "AppIcon.appiconset/icon_${sz}.png"
+  sips -z "$sz" "$sz" "$REPO_TMP/AppIcon-1024.png" --out "AppIcon.appiconset/icon_${sz}.png"
 done
 # Author Contents.json mapping each size/scale to its file, then verify:
-# actool --compile /tmp/out --app-icon AppIcon --platform iphoneos \
+# actool --compile "$REPO_TMP/actool-out" --app-icon AppIcon --platform iphoneos \
 #   --minimum-deployment-target 17.0 AppIcon.appiconset   # expect a clean compile
 ```
 

--- a/bundles/ai-agents/skills/codex-image-gen/plugin.json
+++ b/bundles/ai-agents/skills/codex-image-gen/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-image-gen",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generate images via the Codex CLI and extract the PNG from the session rollout.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/ai-agents/skills/codex-image-gen/scripts/extract-codex-image.py
+++ b/bundles/ai-agents/skills/codex-image-gen/scripts/extract-codex-image.py
@@ -11,7 +11,7 @@ Usage:
     extract-codex-image.py <session-id> <out.png>
 
 Example:
-    extract-codex-image.py 0f4c1e2a-... /tmp/out.png
+    extract-codex-image.py 0f4c1e2a-... .tmp/out.png
 """
 
 import base64

--- a/bundles/dev-loop/skills/feature-intake/SKILL.md
+++ b/bundles/dev-loop/skills/feature-intake/SKILL.md
@@ -5,7 +5,7 @@ compatibility: Requires GitHub CLI gh for GitHub issue and project-board operati
 disable-model-invocation: true
 allowed-tools: Bash(gh *) Bash(git *)
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "feature-intake, prd, github, kanban, requirements, ears"
   author: Ship Shit Dev
 when_to_use: "feature intake, client requirement, stakeholder requirement, write this as a PRD, create kanban tickets, push to GitHub board, turn this idea into issues, /feature"
@@ -303,8 +303,10 @@ Show the parent and sub-issue draft. Wait for approval before writing to GitHub.
 After approval, create the parent first, then sub-issues:
 
 ```bash
-gh issue create --title "<short imperative title>" --body-file /tmp/parent-prd.md --label "type:feature"
-gh issue create --title "[backend] <title>" --body-file /tmp/backend.md --label "type:feature"
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+gh issue create --title "<short imperative title>" --body-file "$REPO_TMP/parent-prd.md" --label "type:feature"
+gh issue create --title "[backend] <title>" --body-file "$REPO_TMP/backend.md" --label "type:feature"
 ```
 
 Link sub-issues using the repository's supported GitHub sub-issue API or tracker

--- a/bundles/dev-loop/skills/feature-intake/plugin.json
+++ b/bundles/dev-loop/skills/feature-intake/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-intake",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Capture client requirements as PRD epics, sub-issues, and GitHub Projects kanban items.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-loop/skills/setup-agent-routing/SKILL.md
+++ b/bundles/dev-loop/skills/setup-agent-routing/SKILL.md
@@ -3,7 +3,7 @@ name: setup-agent-routing
 description: Sets up an `## Agent skills` routing block in CLAUDE.md/AGENTS.md plus docs/agents/ so the dev-loop skills (executing-plans, feature-intake, prd-writer, qa-reviewer) know this repo's GitHub issue tracker, kanban label vocabulary, and domain doc layout. Run once per repo before first use of the loop, or when those skills appear to lack tracker, label, or domain context.
 license: MIT
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "setup, routing, github, labels, dev-loop"
   author: Ship Shit Dev
 allowed-tools: Bash(git remote*) Bash(gh label list*) Bash(gh project list*) Bash(gh repo view*)

--- a/bundles/dev-loop/skills/setup-agent-routing/plugin.json
+++ b/bundles/dev-loop/skills/setup-agent-routing/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-agent-routing",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Write repo agent-routing docs for dev-loop tracker, labels, and domain layout.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-loop/skills/setup-agent-routing/references/issue-tracker-github.md
+++ b/bundles/dev-loop/skills/setup-agent-routing/references/issue-tracker-github.md
@@ -30,8 +30,10 @@ live in `.github/agent-loop.env`.
 ## Command vocabulary
 
 ```bash
-# Create (use --body-file with a heredoc/temp file for multi-line PRDs)
-gh issue create --title "<title>" --body-file /tmp/body.md --label "type:feature"
+# Create (use --body-file under the current repo's .tmp/ for multi-line PRDs)
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+gh issue create --title "<title>" --body-file "$REPO_TMP/body.md" --label "type:feature"
 
 # Read one issue with full comment history (rejection + triage notes live here)
 gh issue view <number> --comments

--- a/bundles/dev-workflow/skills/grok-review/SKILL.md
+++ b/bundles/dev-workflow/skills/grok-review/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `grok` CLI (logged in) and git; gh for PR targets.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "code-review, second-opinion, grok, cli, cross-check"
   author: Ship Shit Dev
 allowed-tools: Bash(git *) Bash(gh *) Bash(grok *) Bash(command -v *) Bash(mktemp *)
@@ -98,7 +98,9 @@ The engine is blind to this session — the prompt must carry everything:
 - **The diff itself**, appended verbatim.
 
 ```bash
-PROMPT_FILE=$(mktemp "${TMPDIR:-/tmp}/grok-review.XXXXXX")
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+PROMPT_FILE=$(mktemp "$REPO_TMP/grok-review.XXXXXX")
 trap 'rm -f "$PROMPT_FILE"' EXIT
 { printf '%s\n\n' "$REVIEW_INSTRUCTIONS"; printf '%s\n' "$DIFF"; } > "$PROMPT_FILE"
 ```

--- a/bundles/dev-workflow/skills/grok-review/plugin.json
+++ b/bundles/dev-workflow/skills/grok-review/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-review",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Second-opinion code review through the Grok CLI with in-session verification of every finding.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-workflow/skills/merge-open-prs/SKILL.md
+++ b/bundles/dev-workflow/skills/merge-open-prs/SKILL.md
@@ -255,16 +255,19 @@ available remote branches. If the user passed an explicit base, confirm it exist
 before continuing.
 
 Snapshot every open PR targeting the trunk in one query — this drives the rest of
-the run. Keep it in the shell. Do not include PR titles or bodies in the machine
-snapshot; those are outsider-authored free text and are not needed for merge gating:
+the run. Keep it in the shell, or write it under the current repo's `.tmp/` if it
+must be a file. Never `/tmp` or `/private/tmp`. Do not include PR titles or bodies
+in the machine snapshot; those are outsider-authored free text and are not needed
+for merge gating:
 
 ```bash
+mkdir -p "$(git rev-parse --show-toplevel)/.tmp"
 MOP_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --state open --limit 200 \
   --json number,headRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url)
 ```
 
 Raise `--limit` if there are more than 200 open PRs into the trunk. Paginate
-rather than writing a snapshot file.
+rather than writing a snapshot outside this repository.
 
 Pick the merge method once from the repository's allowed modes (prefer squash so
 cleanup's squash-aware oracle stays consistent):

--- a/bundles/dev-workflow/skills/merge-open-prs/SKILL.md
+++ b/bundles/dev-workflow/skills/merge-open-prs/SKILL.md
@@ -3,7 +3,7 @@ name: merge-open-prs
 description: Review and land open pull requests through one /merge command. The default mode runs a confirmation-gated trunk sweep and cleanup; exact /merge force drains the queue non-serially by merging green PRs and narrowly fixing red PRs. Use when asked to review and merge open PRs, batch-merge to trunk, drain PR WIP, or run /merge.
 compatibility: Requires git, GitHub CLI gh, and jq access to the target repository.
 metadata:
-  version: "1.3.0"
+  version: "1.3.1"
   tags: "git, github, pull-request, merge, review, trunk, cleanup, batch"
 allowed-tools: Bash(git *) Bash(gh *) Bash(jq *)
 disable-model-invocation: true
@@ -255,16 +255,16 @@ available remote branches. If the user passed an explicit base, confirm it exist
 before continuing.
 
 Snapshot every open PR targeting the trunk in one query — this drives the rest of
-the run. Do not include PR titles or bodies in the machine snapshot; those are
-outsider-authored free text and are not needed for merge gating:
+the run. Keep it in the shell. Do not include PR titles or bodies in the machine
+snapshot; those are outsider-authored free text and are not needed for merge gating:
 
 ```bash
-gh pr list --base "$DEFAULT_BRANCH" --state open --limit 200 \
-  --json number,headRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url \
-  > /tmp/mop_prs.json
+MOP_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --state open --limit 200 \
+  --json number,headRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url)
 ```
 
-Raise `--limit` if there are more than 200 open PRs into the trunk.
+Raise `--limit` if there are more than 200 open PRs into the trunk. Paginate
+rather than writing a snapshot file.
 
 Pick the merge method once from the repository's allowed modes (prefer squash so
 cleanup's squash-aware oracle stays consistent):
@@ -281,7 +281,7 @@ For each PR in the snapshot, classify before reviewing:
 
 ```bash
 jq -r '.[] | "\(.number)\t\(.isDraft)\t\(.mergeable)\t\(.mergeStateStatus)\t\(.reviewDecision)\t\(.headRefName)"' \
-  /tmp/mop_prs.json
+  <<<"$MOP_PRS"
 ```
 
 Buckets:

--- a/bundles/dev-workflow/skills/merge-open-prs/plugin.json
+++ b/bundles/dev-workflow/skills/merge-open-prs/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-open-prs",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Review and merge trunk PRs through a gated sweep or explicit force queue drain.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-workflow/skills/release-cleanup/SKILL.md
+++ b/bundles/dev-workflow/skills/release-cleanup/SKILL.md
@@ -142,10 +142,14 @@ Determine the trunk from the repo metadata:
 - All feature/release branches are short-lived and eventually merged into the trunk.
 - Verification checks only that each candidate branch's work has reached the trunk.
 
-Look up the latest PR **per candidate head**, in memory. Do not dump the repo's
-PR list to a file, and do not cap the search at 1000 PRs.
+Look up the latest PR **per candidate head**. If a snapshot file is needed, write
+it under the current repo's `.tmp/` (create it). Never `/tmp` or `/private/tmp`.
+Do not cap the search at 1000 PRs.
 
 ```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+mkdir -p "$REPO_ROOT/.tmp"
+
 latest_pr_for_head() {   # arg: branch name without origin/
   gh pr list --head "$1" --state all --limit 1 \
     --json number,headRefName,baseRefName,state,mergedAt,mergeCommit

--- a/bundles/dev-workflow/skills/release-cleanup/SKILL.md
+++ b/bundles/dev-workflow/skills/release-cleanup/SKILL.md
@@ -3,7 +3,7 @@ name: release-cleanup
 description: Verify a release branch is provably merged into the trunk (default branch) via the squash-aware GitHub PR merge oracle, then prune merged local and remote feature branches and stale git worktrees. Squash-merge aware — uses GitHub PR merge state as the merge oracle, not commit ancestry. Use when the user asks to clean up branches after a deploy, prune worktrees, remove merged branches, or confirm nothing stale was left behind before pruning.
 compatibility: Requires git, GitHub CLI gh, and jq access to the target repository.
 metadata:
-  version: "2.1.1"
+  version: "2.2.0"
   tags: "git, cleanup, branches, worktrees, release, prune, ci-cd, squash-merge, trunk-based"
 allowed-tools: Bash(git *) Bash(gh *) Bash(jq *)
 disable-model-invocation: true
@@ -36,12 +36,15 @@ Consequence if you trust ancestry on a squash repo:
 
 Therefore this skill's merge oracle is **GitHub PR state first, ancestry second**:
 
-A branch's work is IN the production branch iff EITHER
+A branch's work is IN the production branch iff ANY of:
 
 1. its most-recent PR is `MERGED` and that PR's `mergeCommit` is an ancestor of the
    production branch (covers squash, rebase, and merge-commit), OR
 2. the branch tip is an ancestor of the production branch (covers
-   no-PR fast-forwards and merge-commit merges that predate the PR API).
+   no-PR fast-forwards and merge-commit merges that predate the PR API), OR
+3. every unique commit subject still ahead of the trunk matches a merged PR whose
+   `mergeCommit` is in the trunk (covers local retarget/rebase copies whose name
+   no longer matches a PR head).
 
 Only branches that satisfy this are prunable. Everything else is reported, never
 deleted.
@@ -118,10 +121,14 @@ Hard rules:
 5. `git worktree remove --force` and deleting a remote branch the oracle has NOT
    proven-in-prod are never done automatically.
 6. If promotion verification fails, STOP. Do not offer to prune around it.
+7. Run `git`/`gh`/`jq` in the agent shell. If a command is missing, restore
+   `PATH` in that same shell (`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`).
+   Never write a helper script to disk for this skill.
 
 ## Phase 1: Discover Branches and Refresh State
 
 ```bash
+command -v git >/dev/null || export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 gh auth status -h github.com
 git status -sb
 git remote -v
@@ -135,57 +142,82 @@ Determine the trunk from the repo metadata:
 - All feature/release branches are short-lived and eventually merged into the trunk.
 - Verification checks only that each candidate branch's work has reached the trunk.
 
-Snapshot every PR once — this is the data the Merge Oracle runs against:
+Look up the latest PR **per candidate head**, in memory. Do not dump the repo's
+PR list to a file, and do not cap the search at 1000 PRs.
 
 ```bash
-gh pr list --state all --limit 1000 \
-  --json number,headRefName,baseRefName,state,mergedAt,mergeCommit \
-  > /tmp/rc_prs.json
+latest_pr_for_head() {   # arg: branch name without origin/
+  gh pr list --head "$1" --state all --limit 1 \
+    --json number,headRefName,baseRefName,state,mergedAt,mergeCommit
+}
 ```
 
-Raise `--limit` if the repo has more open+closed PRs than that.
+After a squash merge, GitHub often deletes the remote head. Remotes can already
+be just `origin/<trunk>` while leftover **local** branches and worktrees remain.
+Classify remotes, locals, and extra worktrees. A remote-only pass is not enough.
 
 ## Phase 2: Trunk Verification (Hard Gate)
 
-### 2a. Check candidate branches against the trunk
+### 2a. Check candidate refs against the trunk
 
-For each candidate branch (feature branches targeted for cleanup), verify that its
-work has reached the trunk. Ancestry is the first signal, but squash merges require
-corroboration against the latest merged PR for that branch before declaring work missing.
-
-```bash
-TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-
-# Show commits on a candidate branch not yet in the trunk
-git log --oneline origin/${TRUNK}..origin/<branch>
-# Check the PR that merged this branch into the trunk
-gh pr list --base ${TRUNK} --head <branch> --state merged --limit 1 \
-  --json number,mergedAt,mergeCommit
-```
-
-Interpreting a non-empty result:
-
-- Commits exist on the branch that are genuine direct commits not yet in the trunk => NOT MERGED. Report and STOP.
-- All listed commits belong to a PR already squash-merged into the trunk => ancestry artifact, not a real gap. Treat as merged.
-- Distinguish the two by checking whether each ahead-commit's PR is already merged into the trunk.
-
-### 2b. Branch classification (the "nothing is stale" check)
-
-Run the Merge Oracle over every non-protected remote branch. Do NOT use
-`git branch -r --no-merged` for this — it lies on squash repos.
+For each candidate (remote branch, local branch, or extra worktree HEAD), verify
+that its work has reached the trunk. Ancestry is the first signal, but squash
+merges require corroboration against the latest merged PR for that work.
 
 ```bash
 TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
 PROD="origin/${TRUNK}"
 
-classify_branch() {        # arg: branch name without origin/
-  local b="$1" rec st mc base num
-  rec=$(jq -c --arg b "$b" \
-    '[.[]|select(.headRefName==$b)]|sort_by(.number)|last' /tmp/rc_prs.json)
+# Commits on a ref not in the trunk
+git log --oneline "$PROD".."<ref>"
+# PR that landed this head name
+latest_pr_for_head "<branch>"
+```
+
+Interpreting a non-empty ahead range:
+
+- Genuine commits not yet in the trunk => NOT MERGED. Report and STOP.
+- Every ahead subject matches a PR already squash-merged into the trunk =>
+  squash artifact, not a real gap. Treat as merged. This is how local
+  retarget/rebase copies (`*-onto-<trunk>`, `pr-N-rebase`, detached worktree
+  HEADs) get classified when their name no longer matches a PR head.
+
+### 2b. Branch classification (the "nothing is stale" check)
+
+Run the Merge Oracle over every non-protected **remote and local** branch, plus
+each extra worktree. Do NOT use `git branch --merged` / `-r --no-merged`.
+
+```bash
+TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+PROD="origin/${TRUNK}"
+CURRENT="$(git symbolic-ref --quiet --short HEAD || echo)"
+PROTECT="${TRUNK}|${CURRENT:-__none__}|HEAD"
+
+squash_artifact() {      # arg: git ref. 0 = every ahead subject is a merged PR in trunk
+  local ref="$1" sub rec mc subjects
+  subjects=$(git log --format=%s "$PROD".."$ref" 2>/dev/null | sort -u)
+  [ -n "$subjects" ] || return 1
+  while IFS= read -r sub; do
+    [ -z "$sub" ] && continue
+    rec=$(gh pr list --state merged --search "$sub" --limit 20 \
+      --json number,title,mergeCommit \
+      | jq -c --arg s "$sub" '[.[]|select(.title==$s)]|first')
+    [ -n "$rec" ] && [ "$rec" != "null" ] || return 1
+    mc=$(jq -r '.mergeCommit.oid // empty' <<<"$rec")
+    [ -n "$mc" ] && git merge-base --is-ancestor "$mc" "$PROD" 2>/dev/null || return 1
+  done <<< "$subjects"
+}
+
+classify_ref() {         # args: head-name, git-ref to test for ancestry
+  local b="$1" ref="$2" rec st mc base num
+  rec=$(latest_pr_for_head "$b")
+  rec=$(jq -c 'if type=="array" then .[0] else . end' <<<"${rec:-null}")
 
   if [ -z "$rec" ] || [ "$rec" = "null" ]; then
-    git merge-base --is-ancestor "refs/remotes/origin/$b" "$PROD" 2>/dev/null \
+    git merge-base --is-ancestor "$ref" "$PROD" 2>/dev/null \
       && { echo "PRUNABLE_NO_PR_FF"; return; }
+    squash_artifact "$ref" \
+      && { echo "PRUNABLE_SQUASH_ARTIFACT"; return; }
     echo "STRANDED_NO_PR"
     return
   fi
@@ -197,27 +229,33 @@ classify_branch() {        # arg: branch name without origin/
 
   case "$st" in
     OPEN)   echo "IN_FLIGHT_OPEN_PR(#$num->$base)";;
-    CLOSED) git merge-base --is-ancestor "refs/remotes/origin/$b" "$PROD" 2>/dev/null \
+    CLOSED) git merge-base --is-ancestor "$ref" "$PROD" 2>/dev/null \
               && echo "PRUNABLE_CLOSED_PR_IN_PROD(#$num)" \
               || echo "STRANDED_CLOSED_UNMERGED(#$num)";;
     MERGED)
       if [ -n "$mc" ] && git merge-base --is-ancestor "$mc" "$PROD" 2>/dev/null; then
         echo "PRUNABLE_IN_TRUNK(#$num)"
-      elif git merge-base --is-ancestor "refs/remotes/origin/$b" "$PROD" 2>/dev/null; then
+      elif git merge-base --is-ancestor "$ref" "$PROD" 2>/dev/null; then
         echo "PRUNABLE_IN_TRUNK(#$num)"
+      elif squash_artifact "$ref"; then
+        echo "PRUNABLE_SQUASH_ARTIFACT(#$num)"
       else
         echo "MERGED_NOT_YET_IN_TRUNK(#$num->$base)"
       fi;;
   esac
 }
 
-# Drive it over all non-protected remote branches:
-git branch -r --format '%(refname:short)' \
-  | grep -v -- '->' \
-  | sed 's#^origin/##' \
+git branch -r --format '%(refname:short)' | grep -v -- '->' | sed 's#^origin/##' \
   | grep -vxE "origin|${TRUNK}|HEAD" \
-  | while read -r b; do printf '%-50s %s\n' "$b" "$(classify_branch "$b")"; done
+  | while read -r b; do printf 'REMOTE  %-50s %s\n' "$b" "$(classify_ref "$b" "refs/remotes/origin/$b")"; done
+
+git branch --format '%(refname:short)' | grep -vxE "$PROTECT" \
+  | while read -r b; do printf 'LOCAL   %-50s %s\n' "$b" "$(classify_ref "$b" "$b")"; done
 ```
+
+For each extra worktree from `git worktree list --porcelain`, classify its
+checked-out branch the same way. Detached HEAD: use `PRUNABLE_SQUASH_ARTIFACT`
+when `squash_artifact HEAD` succeeds at that path.
 
 Buckets and what they mean:
 
@@ -239,54 +277,29 @@ Gate outcome:
 
 ## Phase 3: Build the Prune Plan (Dry-Run, Default)
 
-The prunable remote set is exactly the branches the oracle tagged `PRUNABLE_*` in
-Phase 2b. Now compute the local and worktree sets the same way.
+The prunable set is exactly the refs the oracle tagged `PRUNABLE_*` in Phase 2b.
+Print three lists from that classification:
 
-```bash
-TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-CURRENT="$(git symbolic-ref --quiet --short HEAD || echo)"
-PROTECT="${TRUNK}|${CURRENT:-__none__}"
+- **Local branches** tagged `PRUNABLE_*` (annotate `needs -D` for squash/rebase).
+- **Remote branches** tagged `PRUNABLE_*`.
+- **Worktrees** whose branch is `PRUNABLE_*` and whose `git -C <path> status --porcelain`
+  is empty. Dirty => SKIP. Unmerged => SKIP. Upstream gone and proven-in-prod =>
+  safe to remove.
 
-# Local branches — classify each with the SAME oracle (reuse classify_branch,
-# but test the LOCAL ref, not origin/, for the ancestry fallback).
-git branch --format '%(refname:short)' \
-  | grep -vxE "$PROTECT" \
-  | while read -r b; do
-      rec=$(jq -c --arg b "$b" \
-        '[.[]|select(.headRefName==$b)]|sort_by(.number)|last' /tmp/rc_prs.json)
-      mc=$(jq -r '.mergeCommit.oid // empty' <<<"${rec:-null}")
-      st=$(jq -r '.state // empty' <<<"${rec:-null}")
-      if { [ "$st" = "MERGED" ] && [ -n "$mc" ] \
-             && git merge-base --is-ancestor "$mc" "$PROD" 2>/dev/null; } \
-         || git merge-base --is-ancestor "$b" "$PROD" 2>/dev/null; then
-        echo "PRUNABLE_LOCAL  $b  (needs -D if squash-merged)"
-      else
-        echo "KEEP_LOCAL      $b  ($st)"
-      fi
-    done
-
-# Worktrees
-git worktree list --porcelain
-```
-
-For each worktree other than the main checkout, classify it:
-
-- Branch proven-in-prod by the oracle AND `git -C <path> status --porcelain` empty => safe to remove.
-- Uncommitted changes => SKIP, report as dirty.
-- Branch not proven-in-prod => SKIP, report as unmerged.
-- Upstream gone (deleted on remote) and proven-in-prod => safe to remove.
-
-Print the plan as three explicit lists — local branches, remote branches,
-worktree paths — each annotated with the oracle verdict and PR number, plus a
-skipped list with reasons (`MERGED_NOT_YET_IN_TRUNK`, `IN_FLIGHT_OPEN_PR`,
+Plus a skipped list with reasons (`MERGED_NOT_YET_IN_TRUNK`, `IN_FLIGHT_OPEN_PR`,
 `STRANDED_*`, dirty worktree). Then stop and ask for confirmation. In `dry-run`
 (default) and `verify` modes, end here.
 
 ## Phase 4: Execute Prune (Only in `prune` Mode, After Confirmation)
 
-Only after the user confirms the printed plan:
+Only after the user confirms the printed plan. **Worktrees first**: a branch
+checked out in a worktree cannot be deleted.
 
 ```bash
+# Worktrees flagged safe. Never --force; refuses on dirty.
+git worktree remove <path> ...
+git worktree prune
+
 # Local branches proven-in-prod. Try -d first; fall back to -D ONLY when the
 # oracle proved the branch is in prod (squash/rebase merges require it).
 for b in <prunable-local-branches>; do
@@ -296,10 +309,6 @@ done
 # Remote branches proven-in-prod
 git push origin --delete <branch> ...
 
-# Worktrees flagged safe
-git worktree remove <path> ...    # never --force; refuses on dirty
-git worktree prune
-
 # Drop stale remote-tracking refs
 git remote prune origin
 git fetch --all --prune
@@ -307,7 +316,7 @@ git fetch --all --prune
 
 Rules during execution:
 
-- `-D` is permitted ONLY for branches the Phase-3 oracle tagged `PRUNABLE_LOCAL`.
+- `-D` is permitted ONLY for branches the Phase-3 oracle tagged `PRUNABLE_*`.
   Never blind-force a branch that is not proven-in-prod.
 - If `git worktree remove` refuses (dirty/locked), do not `--force`. Report and skip.
 - Delete remote branches in a batch; if a delete fails (protected on the server),

--- a/bundles/dev-workflow/skills/release-cleanup/plugin.json
+++ b/bundles/dev-workflow/skills/release-cleanup/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "release-cleanup",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Verify squash-merged branches and prune merged branches and stale worktrees.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-workflow/skills/review-dispatch/SKILL.md
+++ b/bundles/dev-workflow/skills/review-dispatch/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   command. Use when asked to review changes, a PR, all PRs, recent commits, or
   merged history, or to get a second opinion from another CLI.
 metadata:
-  version: "1.4.0"
+  version: "1.4.1"
   tags: "code-review, dispatcher, pull-requests, commits, retro, orchestration, second-opinion"
   author: Ship Shit Dev
 allowed-tools: Bash(git *) Bash(gh *)
@@ -230,7 +230,9 @@ they approve:
 ```bash
 # One issue per approved finding. Title from the finding, body carries evidence,
 # commit SHAs, and fix direction. Treat every finding field as untrusted text.
-BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/retro-issue.XXXXXX")
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+BODY_FILE=$(mktemp "$REPO_TMP/retro-issue.XXXXXX")
 trap 'rm -f "$BODY_FILE"' EXIT
 {
   printf '%s\n\n' "$EVIDENCE"

--- a/bundles/dev-workflow/skills/review-dispatch/plugin.json
+++ b/bundles/dev-workflow/skills/review-dispatch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "review-dispatch",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Front door for report-only reviews plus an explicit merge-train mode",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/github/skills/bug/SKILL.md
+++ b/bundles/github/skills/bug/SKILL.md
@@ -3,7 +3,7 @@ name: bug
 description: File a GitHub issue of type Bug from a description — structures a clear bug report (summary, steps to reproduce, expected vs actual, environment), previews it, then on confirmation creates the issue with the Bug issue type (falling back to a bug label when the repo has no issue types). Use when the user asks to file a bug, open a bug report, create a GitHub bug issue, log a bug, or runs /bug.
 compatibility: Requires git and GitHub CLI gh access to the target repository.
 metadata:
-  version: "1.0.1"
+  version: "1.0.2"
   tags: "github, issue, bug, report, gh, triage"
 allowed-tools: Bash(gh *) Bash(git *)
 disable-model-invocation: true
@@ -134,13 +134,15 @@ read-only or dry-run request, end here and file nothing.
 
 ## Phase 4: Create the Issue
 
-Only after confirmation, write the body to a temp file (to preserve formatting) and
-create the issue.
+Only after confirmation, write the body under the current repo's `.tmp/` (to
+preserve formatting) and create the issue.
 
 Preferred — Bug issue type:
 
 ```bash
-gh issue create --title "<title>" --body-file /tmp/bug_body.md --type Bug
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+gh issue create --title "<title>" --body-file "$REPO_TMP/bug_body.md" --type Bug
 ```
 
 Fallback — `bug` label (create the label first only if it is missing and the user
@@ -148,7 +150,7 @@ agreed):
 
 ```bash
 gh label create bug --color d73a4a --description "Something isn't working" 2>/dev/null || true
-gh issue create --title "<title>" --body-file /tmp/bug_body.md --label bug
+gh issue create --title "<title>" --body-file "$REPO_TMP/bug_body.md" --label bug
 ```
 
 Add `--assignee`, `--label`, `--milestone`, or `--project` only for values the user

--- a/bundles/github/skills/bug/plugin.json
+++ b/bundles/github/skills/bug/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bug",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "File a structured GitHub Bug issue with repro steps, environment, and fallback labels.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/github/skills/feature-intake/SKILL.md
+++ b/bundles/github/skills/feature-intake/SKILL.md
@@ -5,7 +5,7 @@ compatibility: Requires GitHub CLI gh for GitHub issue and project-board operati
 disable-model-invocation: true
 allowed-tools: Bash(gh *) Bash(git *)
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "feature-intake, prd, github, kanban, requirements, ears"
   author: Ship Shit Dev
 when_to_use: "feature intake, client requirement, stakeholder requirement, write this as a PRD, create kanban tickets, push to GitHub board, turn this idea into issues, /feature"
@@ -303,8 +303,10 @@ Show the parent and sub-issue draft. Wait for approval before writing to GitHub.
 After approval, create the parent first, then sub-issues:
 
 ```bash
-gh issue create --title "<short imperative title>" --body-file /tmp/parent-prd.md --label "type:feature"
-gh issue create --title "[backend] <title>" --body-file /tmp/backend.md --label "type:feature"
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+gh issue create --title "<short imperative title>" --body-file "$REPO_TMP/parent-prd.md" --label "type:feature"
+gh issue create --title "[backend] <title>" --body-file "$REPO_TMP/backend.md" --label "type:feature"
 ```
 
 Link sub-issues using the repository's supported GitHub sub-issue API or tracker

--- a/bundles/github/skills/feature-intake/plugin.json
+++ b/bundles/github/skills/feature-intake/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-intake",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Capture client requirements as PRD epics, sub-issues, and GitHub Projects kanban items.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/github/skills/gh-review-suggestions/SKILL.md
+++ b/bundles/github/skills/gh-review-suggestions/SKILL.md
@@ -5,7 +5,7 @@ compatibility: Requires GitHub CLI gh access to the repository. The bundled diff
 disable-model-invocation: true
 allowed-tools: Bash(git *) Bash(gh *) Bash(node *) Bash(bun *)
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "github, pull-requests, review, suggestions"
 ---
 
@@ -56,7 +56,9 @@ Delegates To:
    ```bash
    gh auth status -h github.com
    gh pr view <pr> --json number,url,headRefOid,commits,files,reviewDecision
-   gh pr diff <pr> > /tmp/pr.diff
+   REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+   mkdir -p "$REPO_TMP"
+   gh pr diff <pr> > "$REPO_TMP/pr.diff"
    ```
 
 2. Review changed files, not the whole repository. Focus on:
@@ -81,7 +83,7 @@ Delegates To:
 
    ```bash
    node ${CLAUDE_SKILL_DIR}/scripts/diff-line-position.mjs \
-     --diff /tmp/pr.diff \
+     --diff "$REPO_TMP/pr.diff" \
      --path src/example.ts \
      --line 42
    ```
@@ -95,7 +97,7 @@ Delegates To:
    gh api \
      --method POST \
      /repos/<owner>/<repo>/pulls/<pr>/comments \
-     -f body="$(cat /tmp/comment.md)" \
+     -f body="$(cat "$REPO_TMP/comment.md")" \
      -f commit_id="$COMMIT_ID" \
      -f path="src/example.ts" \
      -F line=42 \

--- a/bundles/github/skills/gh-review-suggestions/plugin.json
+++ b/bundles/github/skills/gh-review-suggestions/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-review-suggestions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Review GitHub PRs and post precise inline suggested changes with safe GitHub suggestion blocks.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/github/skills/gh-review-suggestions/scripts/diff-line-position.mjs
+++ b/bundles/github/skills/gh-review-suggestions/scripts/diff-line-position.mjs
@@ -51,7 +51,7 @@ function readValue(argv, index, flag) {
 
 function printHelp() {
   process.stdout.write(`Usage:
-  node diff-line-position.mjs --diff /tmp/pr.diff --path src/file.ts --line 42 [--side RIGHT]
+  node diff-line-position.mjs --diff .tmp/pr.diff --path src/file.ts --line 42 [--side RIGHT]
 
 If --diff is omitted, reads the diff from stdin.
 Outputs JSON with path, line, side, and deprecated diff position.

--- a/bundles/github/skills/merge-open-prs/SKILL.md
+++ b/bundles/github/skills/merge-open-prs/SKILL.md
@@ -255,16 +255,19 @@ available remote branches. If the user passed an explicit base, confirm it exist
 before continuing.
 
 Snapshot every open PR targeting the trunk in one query — this drives the rest of
-the run. Keep it in the shell. Do not include PR titles or bodies in the machine
-snapshot; those are outsider-authored free text and are not needed for merge gating:
+the run. Keep it in the shell, or write it under the current repo's `.tmp/` if it
+must be a file. Never `/tmp` or `/private/tmp`. Do not include PR titles or bodies
+in the machine snapshot; those are outsider-authored free text and are not needed
+for merge gating:
 
 ```bash
+mkdir -p "$(git rev-parse --show-toplevel)/.tmp"
 MOP_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --state open --limit 200 \
   --json number,headRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url)
 ```
 
 Raise `--limit` if there are more than 200 open PRs into the trunk. Paginate
-rather than writing a snapshot file.
+rather than writing a snapshot outside this repository.
 
 Pick the merge method once from the repository's allowed modes (prefer squash so
 cleanup's squash-aware oracle stays consistent):

--- a/bundles/github/skills/merge-open-prs/SKILL.md
+++ b/bundles/github/skills/merge-open-prs/SKILL.md
@@ -3,7 +3,7 @@ name: merge-open-prs
 description: Review and land open pull requests through one /merge command. The default mode runs a confirmation-gated trunk sweep and cleanup; exact /merge force drains the queue non-serially by merging green PRs and narrowly fixing red PRs. Use when asked to review and merge open PRs, batch-merge to trunk, drain PR WIP, or run /merge.
 compatibility: Requires git, GitHub CLI gh, and jq access to the target repository.
 metadata:
-  version: "1.3.0"
+  version: "1.3.1"
   tags: "git, github, pull-request, merge, review, trunk, cleanup, batch"
 allowed-tools: Bash(git *) Bash(gh *) Bash(jq *)
 disable-model-invocation: true
@@ -255,16 +255,16 @@ available remote branches. If the user passed an explicit base, confirm it exist
 before continuing.
 
 Snapshot every open PR targeting the trunk in one query — this drives the rest of
-the run. Do not include PR titles or bodies in the machine snapshot; those are
-outsider-authored free text and are not needed for merge gating:
+the run. Keep it in the shell. Do not include PR titles or bodies in the machine
+snapshot; those are outsider-authored free text and are not needed for merge gating:
 
 ```bash
-gh pr list --base "$DEFAULT_BRANCH" --state open --limit 200 \
-  --json number,headRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url \
-  > /tmp/mop_prs.json
+MOP_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --state open --limit 200 \
+  --json number,headRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url)
 ```
 
-Raise `--limit` if there are more than 200 open PRs into the trunk.
+Raise `--limit` if there are more than 200 open PRs into the trunk. Paginate
+rather than writing a snapshot file.
 
 Pick the merge method once from the repository's allowed modes (prefer squash so
 cleanup's squash-aware oracle stays consistent):
@@ -281,7 +281,7 @@ For each PR in the snapshot, classify before reviewing:
 
 ```bash
 jq -r '.[] | "\(.number)\t\(.isDraft)\t\(.mergeable)\t\(.mergeStateStatus)\t\(.reviewDecision)\t\(.headRefName)"' \
-  /tmp/mop_prs.json
+  <<<"$MOP_PRS"
 ```
 
 Buckets:

--- a/bundles/github/skills/merge-open-prs/plugin.json
+++ b/bundles/github/skills/merge-open-prs/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-open-prs",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Review and merge trunk PRs through a gated sweep or explicit force queue drain.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/github/skills/release-cleanup/SKILL.md
+++ b/bundles/github/skills/release-cleanup/SKILL.md
@@ -142,10 +142,14 @@ Determine the trunk from the repo metadata:
 - All feature/release branches are short-lived and eventually merged into the trunk.
 - Verification checks only that each candidate branch's work has reached the trunk.
 
-Look up the latest PR **per candidate head**, in memory. Do not dump the repo's
-PR list to a file, and do not cap the search at 1000 PRs.
+Look up the latest PR **per candidate head**. If a snapshot file is needed, write
+it under the current repo's `.tmp/` (create it). Never `/tmp` or `/private/tmp`.
+Do not cap the search at 1000 PRs.
 
 ```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+mkdir -p "$REPO_ROOT/.tmp"
+
 latest_pr_for_head() {   # arg: branch name without origin/
   gh pr list --head "$1" --state all --limit 1 \
     --json number,headRefName,baseRefName,state,mergedAt,mergeCommit

--- a/bundles/github/skills/release-cleanup/SKILL.md
+++ b/bundles/github/skills/release-cleanup/SKILL.md
@@ -3,7 +3,7 @@ name: release-cleanup
 description: Verify a release branch is provably merged into the trunk (default branch) via the squash-aware GitHub PR merge oracle, then prune merged local and remote feature branches and stale git worktrees. Squash-merge aware — uses GitHub PR merge state as the merge oracle, not commit ancestry. Use when the user asks to clean up branches after a deploy, prune worktrees, remove merged branches, or confirm nothing stale was left behind before pruning.
 compatibility: Requires git, GitHub CLI gh, and jq access to the target repository.
 metadata:
-  version: "2.1.1"
+  version: "2.2.0"
   tags: "git, cleanup, branches, worktrees, release, prune, ci-cd, squash-merge, trunk-based"
 allowed-tools: Bash(git *) Bash(gh *) Bash(jq *)
 disable-model-invocation: true
@@ -36,12 +36,15 @@ Consequence if you trust ancestry on a squash repo:
 
 Therefore this skill's merge oracle is **GitHub PR state first, ancestry second**:
 
-A branch's work is IN the production branch iff EITHER
+A branch's work is IN the production branch iff ANY of:
 
 1. its most-recent PR is `MERGED` and that PR's `mergeCommit` is an ancestor of the
    production branch (covers squash, rebase, and merge-commit), OR
 2. the branch tip is an ancestor of the production branch (covers
-   no-PR fast-forwards and merge-commit merges that predate the PR API).
+   no-PR fast-forwards and merge-commit merges that predate the PR API), OR
+3. every unique commit subject still ahead of the trunk matches a merged PR whose
+   `mergeCommit` is in the trunk (covers local retarget/rebase copies whose name
+   no longer matches a PR head).
 
 Only branches that satisfy this are prunable. Everything else is reported, never
 deleted.
@@ -118,10 +121,14 @@ Hard rules:
 5. `git worktree remove --force` and deleting a remote branch the oracle has NOT
    proven-in-prod are never done automatically.
 6. If promotion verification fails, STOP. Do not offer to prune around it.
+7. Run `git`/`gh`/`jq` in the agent shell. If a command is missing, restore
+   `PATH` in that same shell (`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`).
+   Never write a helper script to disk for this skill.
 
 ## Phase 1: Discover Branches and Refresh State
 
 ```bash
+command -v git >/dev/null || export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 gh auth status -h github.com
 git status -sb
 git remote -v
@@ -135,57 +142,82 @@ Determine the trunk from the repo metadata:
 - All feature/release branches are short-lived and eventually merged into the trunk.
 - Verification checks only that each candidate branch's work has reached the trunk.
 
-Snapshot every PR once — this is the data the Merge Oracle runs against:
+Look up the latest PR **per candidate head**, in memory. Do not dump the repo's
+PR list to a file, and do not cap the search at 1000 PRs.
 
 ```bash
-gh pr list --state all --limit 1000 \
-  --json number,headRefName,baseRefName,state,mergedAt,mergeCommit \
-  > /tmp/rc_prs.json
+latest_pr_for_head() {   # arg: branch name without origin/
+  gh pr list --head "$1" --state all --limit 1 \
+    --json number,headRefName,baseRefName,state,mergedAt,mergeCommit
+}
 ```
 
-Raise `--limit` if the repo has more open+closed PRs than that.
+After a squash merge, GitHub often deletes the remote head. Remotes can already
+be just `origin/<trunk>` while leftover **local** branches and worktrees remain.
+Classify remotes, locals, and extra worktrees. A remote-only pass is not enough.
 
 ## Phase 2: Trunk Verification (Hard Gate)
 
-### 2a. Check candidate branches against the trunk
+### 2a. Check candidate refs against the trunk
 
-For each candidate branch (feature branches targeted for cleanup), verify that its
-work has reached the trunk. Ancestry is the first signal, but squash merges require
-corroboration against the latest merged PR for that branch before declaring work missing.
-
-```bash
-TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-
-# Show commits on a candidate branch not yet in the trunk
-git log --oneline origin/${TRUNK}..origin/<branch>
-# Check the PR that merged this branch into the trunk
-gh pr list --base ${TRUNK} --head <branch> --state merged --limit 1 \
-  --json number,mergedAt,mergeCommit
-```
-
-Interpreting a non-empty result:
-
-- Commits exist on the branch that are genuine direct commits not yet in the trunk => NOT MERGED. Report and STOP.
-- All listed commits belong to a PR already squash-merged into the trunk => ancestry artifact, not a real gap. Treat as merged.
-- Distinguish the two by checking whether each ahead-commit's PR is already merged into the trunk.
-
-### 2b. Branch classification (the "nothing is stale" check)
-
-Run the Merge Oracle over every non-protected remote branch. Do NOT use
-`git branch -r --no-merged` for this — it lies on squash repos.
+For each candidate (remote branch, local branch, or extra worktree HEAD), verify
+that its work has reached the trunk. Ancestry is the first signal, but squash
+merges require corroboration against the latest merged PR for that work.
 
 ```bash
 TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
 PROD="origin/${TRUNK}"
 
-classify_branch() {        # arg: branch name without origin/
-  local b="$1" rec st mc base num
-  rec=$(jq -c --arg b "$b" \
-    '[.[]|select(.headRefName==$b)]|sort_by(.number)|last' /tmp/rc_prs.json)
+# Commits on a ref not in the trunk
+git log --oneline "$PROD".."<ref>"
+# PR that landed this head name
+latest_pr_for_head "<branch>"
+```
+
+Interpreting a non-empty ahead range:
+
+- Genuine commits not yet in the trunk => NOT MERGED. Report and STOP.
+- Every ahead subject matches a PR already squash-merged into the trunk =>
+  squash artifact, not a real gap. Treat as merged. This is how local
+  retarget/rebase copies (`*-onto-<trunk>`, `pr-N-rebase`, detached worktree
+  HEADs) get classified when their name no longer matches a PR head.
+
+### 2b. Branch classification (the "nothing is stale" check)
+
+Run the Merge Oracle over every non-protected **remote and local** branch, plus
+each extra worktree. Do NOT use `git branch --merged` / `-r --no-merged`.
+
+```bash
+TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+PROD="origin/${TRUNK}"
+CURRENT="$(git symbolic-ref --quiet --short HEAD || echo)"
+PROTECT="${TRUNK}|${CURRENT:-__none__}|HEAD"
+
+squash_artifact() {      # arg: git ref. 0 = every ahead subject is a merged PR in trunk
+  local ref="$1" sub rec mc subjects
+  subjects=$(git log --format=%s "$PROD".."$ref" 2>/dev/null | sort -u)
+  [ -n "$subjects" ] || return 1
+  while IFS= read -r sub; do
+    [ -z "$sub" ] && continue
+    rec=$(gh pr list --state merged --search "$sub" --limit 20 \
+      --json number,title,mergeCommit \
+      | jq -c --arg s "$sub" '[.[]|select(.title==$s)]|first')
+    [ -n "$rec" ] && [ "$rec" != "null" ] || return 1
+    mc=$(jq -r '.mergeCommit.oid // empty' <<<"$rec")
+    [ -n "$mc" ] && git merge-base --is-ancestor "$mc" "$PROD" 2>/dev/null || return 1
+  done <<< "$subjects"
+}
+
+classify_ref() {         # args: head-name, git-ref to test for ancestry
+  local b="$1" ref="$2" rec st mc base num
+  rec=$(latest_pr_for_head "$b")
+  rec=$(jq -c 'if type=="array" then .[0] else . end' <<<"${rec:-null}")
 
   if [ -z "$rec" ] || [ "$rec" = "null" ]; then
-    git merge-base --is-ancestor "refs/remotes/origin/$b" "$PROD" 2>/dev/null \
+    git merge-base --is-ancestor "$ref" "$PROD" 2>/dev/null \
       && { echo "PRUNABLE_NO_PR_FF"; return; }
+    squash_artifact "$ref" \
+      && { echo "PRUNABLE_SQUASH_ARTIFACT"; return; }
     echo "STRANDED_NO_PR"
     return
   fi
@@ -197,27 +229,33 @@ classify_branch() {        # arg: branch name without origin/
 
   case "$st" in
     OPEN)   echo "IN_FLIGHT_OPEN_PR(#$num->$base)";;
-    CLOSED) git merge-base --is-ancestor "refs/remotes/origin/$b" "$PROD" 2>/dev/null \
+    CLOSED) git merge-base --is-ancestor "$ref" "$PROD" 2>/dev/null \
               && echo "PRUNABLE_CLOSED_PR_IN_PROD(#$num)" \
               || echo "STRANDED_CLOSED_UNMERGED(#$num)";;
     MERGED)
       if [ -n "$mc" ] && git merge-base --is-ancestor "$mc" "$PROD" 2>/dev/null; then
         echo "PRUNABLE_IN_TRUNK(#$num)"
-      elif git merge-base --is-ancestor "refs/remotes/origin/$b" "$PROD" 2>/dev/null; then
+      elif git merge-base --is-ancestor "$ref" "$PROD" 2>/dev/null; then
         echo "PRUNABLE_IN_TRUNK(#$num)"
+      elif squash_artifact "$ref"; then
+        echo "PRUNABLE_SQUASH_ARTIFACT(#$num)"
       else
         echo "MERGED_NOT_YET_IN_TRUNK(#$num->$base)"
       fi;;
   esac
 }
 
-# Drive it over all non-protected remote branches:
-git branch -r --format '%(refname:short)' \
-  | grep -v -- '->' \
-  | sed 's#^origin/##' \
+git branch -r --format '%(refname:short)' | grep -v -- '->' | sed 's#^origin/##' \
   | grep -vxE "origin|${TRUNK}|HEAD" \
-  | while read -r b; do printf '%-50s %s\n' "$b" "$(classify_branch "$b")"; done
+  | while read -r b; do printf 'REMOTE  %-50s %s\n' "$b" "$(classify_ref "$b" "refs/remotes/origin/$b")"; done
+
+git branch --format '%(refname:short)' | grep -vxE "$PROTECT" \
+  | while read -r b; do printf 'LOCAL   %-50s %s\n' "$b" "$(classify_ref "$b" "$b")"; done
 ```
+
+For each extra worktree from `git worktree list --porcelain`, classify its
+checked-out branch the same way. Detached HEAD: use `PRUNABLE_SQUASH_ARTIFACT`
+when `squash_artifact HEAD` succeeds at that path.
 
 Buckets and what they mean:
 
@@ -239,54 +277,29 @@ Gate outcome:
 
 ## Phase 3: Build the Prune Plan (Dry-Run, Default)
 
-The prunable remote set is exactly the branches the oracle tagged `PRUNABLE_*` in
-Phase 2b. Now compute the local and worktree sets the same way.
+The prunable set is exactly the refs the oracle tagged `PRUNABLE_*` in Phase 2b.
+Print three lists from that classification:
 
-```bash
-TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-CURRENT="$(git symbolic-ref --quiet --short HEAD || echo)"
-PROTECT="${TRUNK}|${CURRENT:-__none__}"
+- **Local branches** tagged `PRUNABLE_*` (annotate `needs -D` for squash/rebase).
+- **Remote branches** tagged `PRUNABLE_*`.
+- **Worktrees** whose branch is `PRUNABLE_*` and whose `git -C <path> status --porcelain`
+  is empty. Dirty => SKIP. Unmerged => SKIP. Upstream gone and proven-in-prod =>
+  safe to remove.
 
-# Local branches — classify each with the SAME oracle (reuse classify_branch,
-# but test the LOCAL ref, not origin/, for the ancestry fallback).
-git branch --format '%(refname:short)' \
-  | grep -vxE "$PROTECT" \
-  | while read -r b; do
-      rec=$(jq -c --arg b "$b" \
-        '[.[]|select(.headRefName==$b)]|sort_by(.number)|last' /tmp/rc_prs.json)
-      mc=$(jq -r '.mergeCommit.oid // empty' <<<"${rec:-null}")
-      st=$(jq -r '.state // empty' <<<"${rec:-null}")
-      if { [ "$st" = "MERGED" ] && [ -n "$mc" ] \
-             && git merge-base --is-ancestor "$mc" "$PROD" 2>/dev/null; } \
-         || git merge-base --is-ancestor "$b" "$PROD" 2>/dev/null; then
-        echo "PRUNABLE_LOCAL  $b  (needs -D if squash-merged)"
-      else
-        echo "KEEP_LOCAL      $b  ($st)"
-      fi
-    done
-
-# Worktrees
-git worktree list --porcelain
-```
-
-For each worktree other than the main checkout, classify it:
-
-- Branch proven-in-prod by the oracle AND `git -C <path> status --porcelain` empty => safe to remove.
-- Uncommitted changes => SKIP, report as dirty.
-- Branch not proven-in-prod => SKIP, report as unmerged.
-- Upstream gone (deleted on remote) and proven-in-prod => safe to remove.
-
-Print the plan as three explicit lists — local branches, remote branches,
-worktree paths — each annotated with the oracle verdict and PR number, plus a
-skipped list with reasons (`MERGED_NOT_YET_IN_TRUNK`, `IN_FLIGHT_OPEN_PR`,
+Plus a skipped list with reasons (`MERGED_NOT_YET_IN_TRUNK`, `IN_FLIGHT_OPEN_PR`,
 `STRANDED_*`, dirty worktree). Then stop and ask for confirmation. In `dry-run`
 (default) and `verify` modes, end here.
 
 ## Phase 4: Execute Prune (Only in `prune` Mode, After Confirmation)
 
-Only after the user confirms the printed plan:
+Only after the user confirms the printed plan. **Worktrees first**: a branch
+checked out in a worktree cannot be deleted.
 
 ```bash
+# Worktrees flagged safe. Never --force; refuses on dirty.
+git worktree remove <path> ...
+git worktree prune
+
 # Local branches proven-in-prod. Try -d first; fall back to -D ONLY when the
 # oracle proved the branch is in prod (squash/rebase merges require it).
 for b in <prunable-local-branches>; do
@@ -296,10 +309,6 @@ done
 # Remote branches proven-in-prod
 git push origin --delete <branch> ...
 
-# Worktrees flagged safe
-git worktree remove <path> ...    # never --force; refuses on dirty
-git worktree prune
-
 # Drop stale remote-tracking refs
 git remote prune origin
 git fetch --all --prune
@@ -307,7 +316,7 @@ git fetch --all --prune
 
 Rules during execution:
 
-- `-D` is permitted ONLY for branches the Phase-3 oracle tagged `PRUNABLE_LOCAL`.
+- `-D` is permitted ONLY for branches the Phase-3 oracle tagged `PRUNABLE_*`.
   Never blind-force a branch that is not proven-in-prod.
 - If `git worktree remove` refuses (dirty/locked), do not `--force`. Report and skip.
 - Delete remote branches in a batch; if a delete fails (protected on the server),

--- a/bundles/github/skills/release-cleanup/plugin.json
+++ b/bundles/github/skills/release-cleanup/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "release-cleanup",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Verify squash-merged branches and prune merged branches and stale worktrees.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/infrastructure/skills/ec2-backend-deployer/SKILL.md
+++ b/bundles/infrastructure/skills/ec2-backend-deployer/SKILL.md
@@ -3,7 +3,7 @@ name: ec2-backend-deployer
 description: Deploys backend applications to EC2 instances using Docker, GitHub Actions CI/CD, and Tailscale for secure SSH access. Activates when setting up EC2 deployment pipelines, configuring container registries, or wiring automated deploys for NestJS, Next.js, or Express backends.
 disable-model-invocation: true
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "ec2, deployment, backend"
 ---
 

--- a/bundles/infrastructure/skills/ec2-backend-deployer/plugin.json
+++ b/bundles/infrastructure/skills/ec2-backend-deployer/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ec2-backend-deployer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Expert in deploying backends to EC2 instances using CI/CD pipelines, Docker containers, and GitHub A",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/infrastructure/skills/ec2-backend-deployer/references/full-guide.md
+++ b/bundles/infrastructure/skills/ec2-backend-deployer/references/full-guide.md
@@ -1171,7 +1171,9 @@ HEALTH_URL="${1:-http://localhost:3001/health}"
 SLACK_WEBHOOK="${SLACK_WEBHOOK:-}"
 
 check_health() {
-  response=$(curl -sf -w "%{http_code}" "$HEALTH_URL" -o /tmp/health_response.json 2>/dev/null)
+  APP_DIR="${APP_DIR:-.}"
+  mkdir -p "$APP_DIR/.tmp"
+  response=$(curl -sf -w "%{http_code}" "$HEALTH_URL" -o "$APP_DIR/.tmp/health_response.json" 2>/dev/null)
 
   if [ "$response" = "200" ]; then
     echo "$(date): Health check passed"

--- a/bundles/planning/skills/feature-intake/SKILL.md
+++ b/bundles/planning/skills/feature-intake/SKILL.md
@@ -5,7 +5,7 @@ compatibility: Requires GitHub CLI gh for GitHub issue and project-board operati
 disable-model-invocation: true
 allowed-tools: Bash(gh *) Bash(git *)
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "feature-intake, prd, github, kanban, requirements, ears"
   author: Ship Shit Dev
 when_to_use: "feature intake, client requirement, stakeholder requirement, write this as a PRD, create kanban tickets, push to GitHub board, turn this idea into issues, /feature"
@@ -303,8 +303,10 @@ Show the parent and sub-issue draft. Wait for approval before writing to GitHub.
 After approval, create the parent first, then sub-issues:
 
 ```bash
-gh issue create --title "<short imperative title>" --body-file /tmp/parent-prd.md --label "type:feature"
-gh issue create --title "[backend] <title>" --body-file /tmp/backend.md --label "type:feature"
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+gh issue create --title "<short imperative title>" --body-file "$REPO_TMP/parent-prd.md" --label "type:feature"
+gh issue create --title "[backend] <title>" --body-file "$REPO_TMP/backend.md" --label "type:feature"
 ```
 
 Link sub-issues using the repository's supported GitHub sub-issue API or tracker

--- a/bundles/planning/skills/feature-intake/plugin.json
+++ b/bundles/planning/skills/feature-intake/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-intake",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Capture client requirements as PRD epics, sub-issues, and GitHub Projects kanban items.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/security/skills/open-source-checker/SKILL.md
+++ b/bundles/security/skills/open-source-checker/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   audit before flipping a repo public, or needs to know what is still private in
   code that is about to ship publicly.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   tags: "open-source, publishing, license, audit"
 when_to_use: "open source this repo, make this repository public, is this safe to publish, pre-release audit, what is private in this codebase, check licensing before publishing, going public with this code"
 ---

--- a/bundles/security/skills/open-source-checker/plugin.json
+++ b/bundles/security/skills/open-source-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-source-checker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Audit a private repo before publishing: license, history secrets, private references.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/security/skills/open-source-checker/references/full-guide.md
+++ b/bundles/security/skills/open-source-checker/references/full-guide.md
@@ -406,10 +406,12 @@ onboarding steps that route through internal Slack, wikis, or VPN.
 
 ```bash
 # Variables the code reads, versus what the example documents
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
 grep -rhoE 'process\.env\.[A-Z_]+|os\.environ\[.[A-Z_]+' src/ 2>/dev/null \
-  | grep -oE '[A-Z_]{3,}' | sort -u > /tmp/used-vars
-grep -oE '^[A-Z_]+' .env.example 2>/dev/null | sort -u > /tmp/documented-vars
-comm -23 /tmp/used-vars /tmp/documented-vars     # read but undocumented
+  | grep -oE '[A-Z_]{3,}' | sort -u > "$REPO_TMP/used-vars"
+grep -oE '^[A-Z_]+' .env.example 2>/dev/null | sort -u > "$REPO_TMP/documented-vars"
+comm -23 "$REPO_TMP/used-vars" "$REPO_TMP/documented-vars"     # read but undocumented
 ```
 
 ### 5.3 CI and repository configuration
@@ -503,8 +505,10 @@ copy — the local repository keeps the old objects in its reflog and packs unti
 they are pruned, which can mask an incomplete rewrite.
 
 ```bash
-git clone --mirror <remote-url> /tmp/verify-clone
-gitleaks detect --source /tmp/verify-clone --verbose
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+git clone --mirror <remote-url> "$REPO_TMP/verify-clone"
+gitleaks detect --source "$REPO_TMP/verify-clone" --verbose
 ```
 
 ---

--- a/bundles/session/skills/setup-agent-routing/SKILL.md
+++ b/bundles/session/skills/setup-agent-routing/SKILL.md
@@ -3,7 +3,7 @@ name: setup-agent-routing
 description: Sets up an `## Agent skills` routing block in CLAUDE.md/AGENTS.md plus docs/agents/ so the dev-loop skills (executing-plans, feature-intake, prd-writer, qa-reviewer) know this repo's GitHub issue tracker, kanban label vocabulary, and domain doc layout. Run once per repo before first use of the loop, or when those skills appear to lack tracker, label, or domain context.
 license: MIT
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "setup, routing, github, labels, dev-loop"
   author: Ship Shit Dev
 allowed-tools: Bash(git remote*) Bash(gh label list*) Bash(gh project list*) Bash(gh repo view*)

--- a/bundles/session/skills/setup-agent-routing/plugin.json
+++ b/bundles/session/skills/setup-agent-routing/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-agent-routing",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Write repo agent-routing docs for dev-loop tracker, labels, and domain layout.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/session/skills/setup-agent-routing/references/issue-tracker-github.md
+++ b/bundles/session/skills/setup-agent-routing/references/issue-tracker-github.md
@@ -30,8 +30,10 @@ live in `.github/agent-loop.env`.
 ## Command vocabulary
 
 ```bash
-# Create (use --body-file with a heredoc/temp file for multi-line PRDs)
-gh issue create --title "<title>" --body-file /tmp/body.md --label "type:feature"
+# Create (use --body-file under the current repo's .tmp/ for multi-line PRDs)
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+gh issue create --title "<title>" --body-file "$REPO_TMP/body.md" --label "type:feature"
 
 # Read one issue with full comment history (rejection + triage notes live here)
 gh issue view <number> --comments

--- a/bundles/workspace/skills/open-source-checker/SKILL.md
+++ b/bundles/workspace/skills/open-source-checker/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   audit before flipping a repo public, or needs to know what is still private in
   code that is about to ship publicly.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   tags: "open-source, publishing, license, audit"
 when_to_use: "open source this repo, make this repository public, is this safe to publish, pre-release audit, what is private in this codebase, check licensing before publishing, going public with this code"
 ---

--- a/bundles/workspace/skills/open-source-checker/plugin.json
+++ b/bundles/workspace/skills/open-source-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-source-checker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Audit a private repo before publishing: license, history secrets, private references.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/workspace/skills/open-source-checker/references/full-guide.md
+++ b/bundles/workspace/skills/open-source-checker/references/full-guide.md
@@ -406,10 +406,12 @@ onboarding steps that route through internal Slack, wikis, or VPN.
 
 ```bash
 # Variables the code reads, versus what the example documents
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
 grep -rhoE 'process\.env\.[A-Z_]+|os\.environ\[.[A-Z_]+' src/ 2>/dev/null \
-  | grep -oE '[A-Z_]{3,}' | sort -u > /tmp/used-vars
-grep -oE '^[A-Z_]+' .env.example 2>/dev/null | sort -u > /tmp/documented-vars
-comm -23 /tmp/used-vars /tmp/documented-vars     # read but undocumented
+  | grep -oE '[A-Z_]{3,}' | sort -u > "$REPO_TMP/used-vars"
+grep -oE '^[A-Z_]+' .env.example 2>/dev/null | sort -u > "$REPO_TMP/documented-vars"
+comm -23 "$REPO_TMP/used-vars" "$REPO_TMP/documented-vars"     # read but undocumented
 ```
 
 ### 5.3 CI and repository configuration
@@ -503,8 +505,10 @@ copy — the local repository keeps the old objects in its reflog and packs unti
 they are pruned, which can mask an incomplete rewrite.
 
 ```bash
-git clone --mirror <remote-url> /tmp/verify-clone
-gitleaks detect --source /tmp/verify-clone --verbose
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+git clone --mirror <remote-url> "$REPO_TMP/verify-clone"
+gitleaks detect --source "$REPO_TMP/verify-clone" --verbose
 ```
 
 ---

--- a/catalog.json
+++ b/catalog.json
@@ -53,6 +53,10 @@
       "role": "Git hook configuration"
     },
     {
+      "path": ".tmp/",
+      "role": "Tracked repository content"
+    },
+    {
       "path": "assets/",
       "role": "Static repository assets"
     },

--- a/skills/bug/SKILL.md
+++ b/skills/bug/SKILL.md
@@ -3,7 +3,7 @@ name: bug
 description: File a GitHub issue of type Bug from a description — structures a clear bug report (summary, steps to reproduce, expected vs actual, environment), previews it, then on confirmation creates the issue with the Bug issue type (falling back to a bug label when the repo has no issue types). Use when the user asks to file a bug, open a bug report, create a GitHub bug issue, log a bug, or runs /bug.
 compatibility: Requires git and GitHub CLI gh access to the target repository.
 metadata:
-  version: "1.0.1"
+  version: "1.0.2"
   tags: "github, issue, bug, report, gh, triage"
 allowed-tools: Bash(gh *) Bash(git *)
 disable-model-invocation: true
@@ -134,13 +134,15 @@ read-only or dry-run request, end here and file nothing.
 
 ## Phase 4: Create the Issue
 
-Only after confirmation, write the body to a temp file (to preserve formatting) and
-create the issue.
+Only after confirmation, write the body under the current repo's `.tmp/` (to
+preserve formatting) and create the issue.
 
 Preferred — Bug issue type:
 
 ```bash
-gh issue create --title "<title>" --body-file /tmp/bug_body.md --type Bug
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+gh issue create --title "<title>" --body-file "$REPO_TMP/bug_body.md" --type Bug
 ```
 
 Fallback — `bug` label (create the label first only if it is missing and the user
@@ -148,7 +150,7 @@ agreed):
 
 ```bash
 gh label create bug --color d73a4a --description "Something isn't working" 2>/dev/null || true
-gh issue create --title "<title>" --body-file /tmp/bug_body.md --label bug
+gh issue create --title "<title>" --body-file "$REPO_TMP/bug_body.md" --label bug
 ```
 
 Add `--assignee`, `--label`, `--milestone`, or `--project` only for values the user

--- a/skills/bug/plugin.json
+++ b/skills/bug/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bug",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "File a structured GitHub Bug issue with repro steps, environment, and fallback labels.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/codex-image-gen/SKILL.md
+++ b/skills/codex-image-gen/SKILL.md
@@ -5,7 +5,7 @@ description: >-
 license: MIT
 compatibility: Requires the `codex` CLI (logged in) plus `python3` and `base64`; `sips` is optional for post-processing on macOS.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "codex, image-generation, gpt-image, cli, assets, app-icon"
 when_to_use: "generate an image, make an icon, create an app icon, render an illustration or texture, agent needs an image but has no image tool, codex image generation"
 ---
@@ -52,7 +52,9 @@ model has no other context:
 - Target aspect ratio and rough size.
 
 ```bash
-cat > /tmp/img-prompt.txt <<'PROMPT'
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+cat > "$REPO_TMP/img-prompt.txt" <<'PROMPT'
 A single app icon: a glossy translucent envelope on a soft blue-to-violet
 gradient, Liquid Glass style, centered with even padding, no text, no letters,
 1:1 square, high detail.
@@ -62,7 +64,7 @@ PROMPT
 ### 2. Run `codex exec` and capture stdout
 
 ```bash
-codex exec -s read-only "$(cat /tmp/img-prompt.txt)" 2>&1 | tee /tmp/codex-run.log
+codex exec -s read-only "$(cat "$REPO_TMP/img-prompt.txt")" 2>&1 | tee "$REPO_TMP/codex-run.log"
 ```
 
 Run it in the **foreground**. `exec` returns once the turn completes; in practice
@@ -73,7 +75,7 @@ the `result` is already written to the rollout by then.
 Codex prints a `session id: <uuid>` line. Pull it from the captured log:
 
 ```bash
-SESSION_ID=$(grep -oE 'session id: [0-9a-f-]{36}' /tmp/codex-run.log | awk '{print $3}')
+SESSION_ID=$(grep -oE 'session id: [0-9a-f-]{36}' "$REPO_TMP/codex-run.log" | awk '{print $3}')
 echo "session: $SESSION_ID"
 ```
 
@@ -84,7 +86,7 @@ Walk it, find the largest `result` string (the base64 image), and decode it. Use
 the bundled helper:
 
 ```bash
-python3 scripts/extract-codex-image.py "$SESSION_ID" /tmp/out.png
+python3 scripts/extract-codex-image.py "$SESSION_ID" "$REPO_TMP/out.png"
 ```
 
 ### 5. Assert success
@@ -92,7 +94,7 @@ python3 scripts/extract-codex-image.py "$SESSION_ID" /tmp/out.png
 Confirm the file exists and is a real PNG before using it:
 
 ```bash
-test -s /tmp/out.png && file /tmp/out.png   # expect: PNG image data, 1254 x 1254
+test -s "$REPO_TMP/out.png" && file "$REPO_TMP/out.png"   # expect: PNG image data, 1254 x 1254
 ```
 
 If extraction finds no base64 `result`, the turn did not actually generate an
@@ -105,8 +107,8 @@ Default output is roughly **1254×1254 PNG, RGB, no alpha**. Resize / strip alph
 with `sips` on macOS:
 
 ```bash
-sips -z 1024 1024 /tmp/out.png --out /tmp/icon-1024.png   # downscale
-sips -s format png /tmp/out.png --out /tmp/flat.png        # normalize
+sips -z 1024 1024 "$REPO_TMP/out.png" --out "$REPO_TMP/icon-1024.png"   # downscale
+sips -s format png "$REPO_TMP/out.png" --out "$REPO_TMP/flat.png"        # normalize
 ```
 
 ## Reference extractor
@@ -152,27 +154,29 @@ print("WROTE", out)
 ## Worked example: build a macOS/iOS app icon set
 
 ```bash
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
 # 1. Generate a 1:1 icon master.
-cat > /tmp/icon-prompt.txt <<'PROMPT'
+cat > "$REPO_TMP/icon-prompt.txt" <<'PROMPT'
 App icon: a glossy translucent envelope, Liquid Glass style, soft blue-to-violet
 gradient background, centered, even padding, no text, no letters, 1:1 square.
 PROMPT
-codex exec -s read-only "$(cat /tmp/icon-prompt.txt)" 2>&1 | tee /tmp/codex-run.log
-SESSION_ID=$(grep -oE 'session id: [0-9a-f-]{36}' /tmp/codex-run.log | awk '{print $3}')
-python3 scripts/extract-codex-image.py "$SESSION_ID" /tmp/icon-master.png
+codex exec -s read-only "$(cat "$REPO_TMP/icon-prompt.txt")" 2>&1 | tee "$REPO_TMP/codex-run.log"
+SESSION_ID=$(grep -oE 'session id: [0-9a-f-]{36}' "$REPO_TMP/codex-run.log" | awk '{print $3}')
+python3 scripts/extract-codex-image.py "$SESSION_ID" "$REPO_TMP/icon-master.png"
 
 # 2. Make a 1024 master with no alpha (iOS rejects alpha on the marketing icon).
-sips -z 1024 1024 /tmp/icon-master.png --out /tmp/AppIcon-1024.png
-sips -s format png --setProperty hasAlpha false /tmp/AppIcon-1024.png --out /tmp/AppIcon-1024.png
+sips -z 1024 1024 "$REPO_TMP/icon-master.png" --out "$REPO_TMP/AppIcon-1024.png"
+sips -s format png --setProperty hasAlpha false "$REPO_TMP/AppIcon-1024.png" --out "$REPO_TMP/AppIcon-1024.png"
 
 # 3. Slice into an AppIcon.appiconset (iOS single-size 1024 + the macOS ladder).
 mkdir -p AppIcon.appiconset
-cp /tmp/AppIcon-1024.png AppIcon.appiconset/icon_1024.png
+cp "$REPO_TMP/AppIcon-1024.png" AppIcon.appiconset/icon_1024.png
 for sz in 16 32 64 128 256 512 1024; do
-  sips -z "$sz" "$sz" /tmp/AppIcon-1024.png --out "AppIcon.appiconset/icon_${sz}.png"
+  sips -z "$sz" "$sz" "$REPO_TMP/AppIcon-1024.png" --out "AppIcon.appiconset/icon_${sz}.png"
 done
 # Author Contents.json mapping each size/scale to its file, then verify:
-# actool --compile /tmp/out --app-icon AppIcon --platform iphoneos \
+# actool --compile "$REPO_TMP/actool-out" --app-icon AppIcon --platform iphoneos \
 #   --minimum-deployment-target 17.0 AppIcon.appiconset   # expect a clean compile
 ```
 

--- a/skills/codex-image-gen/plugin.json
+++ b/skills/codex-image-gen/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-image-gen",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generate images via the Codex CLI and extract the PNG from the session rollout.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/codex-image-gen/scripts/extract-codex-image.py
+++ b/skills/codex-image-gen/scripts/extract-codex-image.py
@@ -11,7 +11,7 @@ Usage:
     extract-codex-image.py <session-id> <out.png>
 
 Example:
-    extract-codex-image.py 0f4c1e2a-... /tmp/out.png
+    extract-codex-image.py 0f4c1e2a-... .tmp/out.png
 """
 
 import base64

--- a/skills/ec2-backend-deployer/SKILL.md
+++ b/skills/ec2-backend-deployer/SKILL.md
@@ -3,7 +3,7 @@ name: ec2-backend-deployer
 description: Deploys backend applications to EC2 instances using Docker, GitHub Actions CI/CD, and Tailscale for secure SSH access. Activates when setting up EC2 deployment pipelines, configuring container registries, or wiring automated deploys for NestJS, Next.js, or Express backends.
 disable-model-invocation: true
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "ec2, deployment, backend"
 ---
 

--- a/skills/ec2-backend-deployer/plugin.json
+++ b/skills/ec2-backend-deployer/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ec2-backend-deployer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Expert in deploying backends to EC2 instances using CI/CD pipelines, Docker containers, and GitHub A",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/ec2-backend-deployer/references/full-guide.md
+++ b/skills/ec2-backend-deployer/references/full-guide.md
@@ -1171,7 +1171,9 @@ HEALTH_URL="${1:-http://localhost:3001/health}"
 SLACK_WEBHOOK="${SLACK_WEBHOOK:-}"
 
 check_health() {
-  response=$(curl -sf -w "%{http_code}" "$HEALTH_URL" -o /tmp/health_response.json 2>/dev/null)
+  APP_DIR="${APP_DIR:-.}"
+  mkdir -p "$APP_DIR/.tmp"
+  response=$(curl -sf -w "%{http_code}" "$HEALTH_URL" -o "$APP_DIR/.tmp/health_response.json" 2>/dev/null)
 
   if [ "$response" = "200" ]; then
     echo "$(date): Health check passed"

--- a/skills/feature-intake/SKILL.md
+++ b/skills/feature-intake/SKILL.md
@@ -5,7 +5,7 @@ compatibility: Requires GitHub CLI gh for GitHub issue and project-board operati
 disable-model-invocation: true
 allowed-tools: Bash(gh *) Bash(git *)
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "feature-intake, prd, github, kanban, requirements, ears"
   author: Ship Shit Dev
 when_to_use: "feature intake, client requirement, stakeholder requirement, write this as a PRD, create kanban tickets, push to GitHub board, turn this idea into issues, /feature"
@@ -303,8 +303,10 @@ Show the parent and sub-issue draft. Wait for approval before writing to GitHub.
 After approval, create the parent first, then sub-issues:
 
 ```bash
-gh issue create --title "<short imperative title>" --body-file /tmp/parent-prd.md --label "type:feature"
-gh issue create --title "[backend] <title>" --body-file /tmp/backend.md --label "type:feature"
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+gh issue create --title "<short imperative title>" --body-file "$REPO_TMP/parent-prd.md" --label "type:feature"
+gh issue create --title "[backend] <title>" --body-file "$REPO_TMP/backend.md" --label "type:feature"
 ```
 
 Link sub-issues using the repository's supported GitHub sub-issue API or tracker

--- a/skills/feature-intake/plugin.json
+++ b/skills/feature-intake/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-intake",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Capture client requirements as PRD epics, sub-issues, and GitHub Projects kanban items.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/gh-review-suggestions/SKILL.md
+++ b/skills/gh-review-suggestions/SKILL.md
@@ -5,7 +5,7 @@ compatibility: Requires GitHub CLI gh access to the repository. The bundled diff
 disable-model-invocation: true
 allowed-tools: Bash(git *) Bash(gh *) Bash(node *) Bash(bun *)
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "github, pull-requests, review, suggestions"
 ---
 
@@ -56,7 +56,9 @@ Delegates To:
    ```bash
    gh auth status -h github.com
    gh pr view <pr> --json number,url,headRefOid,commits,files,reviewDecision
-   gh pr diff <pr> > /tmp/pr.diff
+   REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+   mkdir -p "$REPO_TMP"
+   gh pr diff <pr> > "$REPO_TMP/pr.diff"
    ```
 
 2. Review changed files, not the whole repository. Focus on:
@@ -81,7 +83,7 @@ Delegates To:
 
    ```bash
    node ${CLAUDE_SKILL_DIR}/scripts/diff-line-position.mjs \
-     --diff /tmp/pr.diff \
+     --diff "$REPO_TMP/pr.diff" \
      --path src/example.ts \
      --line 42
    ```
@@ -95,7 +97,7 @@ Delegates To:
    gh api \
      --method POST \
      /repos/<owner>/<repo>/pulls/<pr>/comments \
-     -f body="$(cat /tmp/comment.md)" \
+     -f body="$(cat "$REPO_TMP/comment.md")" \
      -f commit_id="$COMMIT_ID" \
      -f path="src/example.ts" \
      -F line=42 \

--- a/skills/gh-review-suggestions/plugin.json
+++ b/skills/gh-review-suggestions/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-review-suggestions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Review GitHub PRs and post precise inline suggested changes with safe GitHub suggestion blocks.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/gh-review-suggestions/scripts/diff-line-position.mjs
+++ b/skills/gh-review-suggestions/scripts/diff-line-position.mjs
@@ -51,7 +51,7 @@ function readValue(argv, index, flag) {
 
 function printHelp() {
   process.stdout.write(`Usage:
-  node diff-line-position.mjs --diff /tmp/pr.diff --path src/file.ts --line 42 [--side RIGHT]
+  node diff-line-position.mjs --diff .tmp/pr.diff --path src/file.ts --line 42 [--side RIGHT]
 
 If --diff is omitted, reads the diff from stdin.
 Outputs JSON with path, line, side, and deprecated diff position.

--- a/skills/grok-review/SKILL.md
+++ b/skills/grok-review/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `grok` CLI (logged in) and git; gh for PR targets.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "code-review, second-opinion, grok, cli, cross-check"
   author: Ship Shit Dev
 allowed-tools: Bash(git *) Bash(gh *) Bash(grok *) Bash(command -v *) Bash(mktemp *)
@@ -98,7 +98,9 @@ The engine is blind to this session — the prompt must carry everything:
 - **The diff itself**, appended verbatim.
 
 ```bash
-PROMPT_FILE=$(mktemp "${TMPDIR:-/tmp}/grok-review.XXXXXX")
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+PROMPT_FILE=$(mktemp "$REPO_TMP/grok-review.XXXXXX")
 trap 'rm -f "$PROMPT_FILE"' EXIT
 { printf '%s\n\n' "$REVIEW_INSTRUCTIONS"; printf '%s\n' "$DIFF"; } > "$PROMPT_FILE"
 ```

--- a/skills/grok-review/plugin.json
+++ b/skills/grok-review/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-review",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Second-opinion code review through the Grok CLI with in-session verification of every finding.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/merge-open-prs/SKILL.md
+++ b/skills/merge-open-prs/SKILL.md
@@ -255,16 +255,19 @@ available remote branches. If the user passed an explicit base, confirm it exist
 before continuing.
 
 Snapshot every open PR targeting the trunk in one query — this drives the rest of
-the run. Keep it in the shell. Do not include PR titles or bodies in the machine
-snapshot; those are outsider-authored free text and are not needed for merge gating:
+the run. Keep it in the shell, or write it under the current repo's `.tmp/` if it
+must be a file. Never `/tmp` or `/private/tmp`. Do not include PR titles or bodies
+in the machine snapshot; those are outsider-authored free text and are not needed
+for merge gating:
 
 ```bash
+mkdir -p "$(git rev-parse --show-toplevel)/.tmp"
 MOP_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --state open --limit 200 \
   --json number,headRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url)
 ```
 
 Raise `--limit` if there are more than 200 open PRs into the trunk. Paginate
-rather than writing a snapshot file.
+rather than writing a snapshot outside this repository.
 
 Pick the merge method once from the repository's allowed modes (prefer squash so
 cleanup's squash-aware oracle stays consistent):

--- a/skills/merge-open-prs/SKILL.md
+++ b/skills/merge-open-prs/SKILL.md
@@ -3,7 +3,7 @@ name: merge-open-prs
 description: Review and land open pull requests through one /merge command. The default mode runs a confirmation-gated trunk sweep and cleanup; exact /merge force drains the queue non-serially by merging green PRs and narrowly fixing red PRs. Use when asked to review and merge open PRs, batch-merge to trunk, drain PR WIP, or run /merge.
 compatibility: Requires git, GitHub CLI gh, and jq access to the target repository.
 metadata:
-  version: "1.3.0"
+  version: "1.3.1"
   tags: "git, github, pull-request, merge, review, trunk, cleanup, batch"
 allowed-tools: Bash(git *) Bash(gh *) Bash(jq *)
 disable-model-invocation: true
@@ -255,16 +255,16 @@ available remote branches. If the user passed an explicit base, confirm it exist
 before continuing.
 
 Snapshot every open PR targeting the trunk in one query — this drives the rest of
-the run. Do not include PR titles or bodies in the machine snapshot; those are
-outsider-authored free text and are not needed for merge gating:
+the run. Keep it in the shell. Do not include PR titles or bodies in the machine
+snapshot; those are outsider-authored free text and are not needed for merge gating:
 
 ```bash
-gh pr list --base "$DEFAULT_BRANCH" --state open --limit 200 \
-  --json number,headRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url \
-  > /tmp/mop_prs.json
+MOP_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --state open --limit 200 \
+  --json number,headRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,url)
 ```
 
-Raise `--limit` if there are more than 200 open PRs into the trunk.
+Raise `--limit` if there are more than 200 open PRs into the trunk. Paginate
+rather than writing a snapshot file.
 
 Pick the merge method once from the repository's allowed modes (prefer squash so
 cleanup's squash-aware oracle stays consistent):
@@ -281,7 +281,7 @@ For each PR in the snapshot, classify before reviewing:
 
 ```bash
 jq -r '.[] | "\(.number)\t\(.isDraft)\t\(.mergeable)\t\(.mergeStateStatus)\t\(.reviewDecision)\t\(.headRefName)"' \
-  /tmp/mop_prs.json
+  <<<"$MOP_PRS"
 ```
 
 Buckets:

--- a/skills/merge-open-prs/plugin.json
+++ b/skills/merge-open-prs/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-open-prs",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Review and merge trunk PRs through a gated sweep or explicit force queue drain.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/open-source-checker/SKILL.md
+++ b/skills/open-source-checker/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   audit before flipping a repo public, or needs to know what is still private in
   code that is about to ship publicly.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   tags: "open-source, publishing, license, audit"
 when_to_use: "open source this repo, make this repository public, is this safe to publish, pre-release audit, what is private in this codebase, check licensing before publishing, going public with this code"
 ---

--- a/skills/open-source-checker/plugin.json
+++ b/skills/open-source-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-source-checker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Audit a private repo before publishing: license, history secrets, private references.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/open-source-checker/references/full-guide.md
+++ b/skills/open-source-checker/references/full-guide.md
@@ -406,10 +406,12 @@ onboarding steps that route through internal Slack, wikis, or VPN.
 
 ```bash
 # Variables the code reads, versus what the example documents
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
 grep -rhoE 'process\.env\.[A-Z_]+|os\.environ\[.[A-Z_]+' src/ 2>/dev/null \
-  | grep -oE '[A-Z_]{3,}' | sort -u > /tmp/used-vars
-grep -oE '^[A-Z_]+' .env.example 2>/dev/null | sort -u > /tmp/documented-vars
-comm -23 /tmp/used-vars /tmp/documented-vars     # read but undocumented
+  | grep -oE '[A-Z_]{3,}' | sort -u > "$REPO_TMP/used-vars"
+grep -oE '^[A-Z_]+' .env.example 2>/dev/null | sort -u > "$REPO_TMP/documented-vars"
+comm -23 "$REPO_TMP/used-vars" "$REPO_TMP/documented-vars"     # read but undocumented
 ```
 
 ### 5.3 CI and repository configuration
@@ -503,8 +505,10 @@ copy — the local repository keeps the old objects in its reflog and packs unti
 they are pruned, which can mask an incomplete rewrite.
 
 ```bash
-git clone --mirror <remote-url> /tmp/verify-clone
-gitleaks detect --source /tmp/verify-clone --verbose
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+git clone --mirror <remote-url> "$REPO_TMP/verify-clone"
+gitleaks detect --source "$REPO_TMP/verify-clone" --verbose
 ```
 
 ---

--- a/skills/release-cleanup/SKILL.md
+++ b/skills/release-cleanup/SKILL.md
@@ -142,10 +142,14 @@ Determine the trunk from the repo metadata:
 - All feature/release branches are short-lived and eventually merged into the trunk.
 - Verification checks only that each candidate branch's work has reached the trunk.
 
-Look up the latest PR **per candidate head**, in memory. Do not dump the repo's
-PR list to a file, and do not cap the search at 1000 PRs.
+Look up the latest PR **per candidate head**. If a snapshot file is needed, write
+it under the current repo's `.tmp/` (create it). Never `/tmp` or `/private/tmp`.
+Do not cap the search at 1000 PRs.
 
 ```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+mkdir -p "$REPO_ROOT/.tmp"
+
 latest_pr_for_head() {   # arg: branch name without origin/
   gh pr list --head "$1" --state all --limit 1 \
     --json number,headRefName,baseRefName,state,mergedAt,mergeCommit

--- a/skills/release-cleanup/SKILL.md
+++ b/skills/release-cleanup/SKILL.md
@@ -3,7 +3,7 @@ name: release-cleanup
 description: Verify a release branch is provably merged into the trunk (default branch) via the squash-aware GitHub PR merge oracle, then prune merged local and remote feature branches and stale git worktrees. Squash-merge aware — uses GitHub PR merge state as the merge oracle, not commit ancestry. Use when the user asks to clean up branches after a deploy, prune worktrees, remove merged branches, or confirm nothing stale was left behind before pruning.
 compatibility: Requires git, GitHub CLI gh, and jq access to the target repository.
 metadata:
-  version: "2.1.1"
+  version: "2.2.0"
   tags: "git, cleanup, branches, worktrees, release, prune, ci-cd, squash-merge, trunk-based"
 allowed-tools: Bash(git *) Bash(gh *) Bash(jq *)
 disable-model-invocation: true
@@ -36,12 +36,15 @@ Consequence if you trust ancestry on a squash repo:
 
 Therefore this skill's merge oracle is **GitHub PR state first, ancestry second**:
 
-A branch's work is IN the production branch iff EITHER
+A branch's work is IN the production branch iff ANY of:
 
 1. its most-recent PR is `MERGED` and that PR's `mergeCommit` is an ancestor of the
    production branch (covers squash, rebase, and merge-commit), OR
 2. the branch tip is an ancestor of the production branch (covers
-   no-PR fast-forwards and merge-commit merges that predate the PR API).
+   no-PR fast-forwards and merge-commit merges that predate the PR API), OR
+3. every unique commit subject still ahead of the trunk matches a merged PR whose
+   `mergeCommit` is in the trunk (covers local retarget/rebase copies whose name
+   no longer matches a PR head).
 
 Only branches that satisfy this are prunable. Everything else is reported, never
 deleted.
@@ -118,10 +121,14 @@ Hard rules:
 5. `git worktree remove --force` and deleting a remote branch the oracle has NOT
    proven-in-prod are never done automatically.
 6. If promotion verification fails, STOP. Do not offer to prune around it.
+7. Run `git`/`gh`/`jq` in the agent shell. If a command is missing, restore
+   `PATH` in that same shell (`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`).
+   Never write a helper script to disk for this skill.
 
 ## Phase 1: Discover Branches and Refresh State
 
 ```bash
+command -v git >/dev/null || export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 gh auth status -h github.com
 git status -sb
 git remote -v
@@ -135,57 +142,82 @@ Determine the trunk from the repo metadata:
 - All feature/release branches are short-lived and eventually merged into the trunk.
 - Verification checks only that each candidate branch's work has reached the trunk.
 
-Snapshot every PR once — this is the data the Merge Oracle runs against:
+Look up the latest PR **per candidate head**, in memory. Do not dump the repo's
+PR list to a file, and do not cap the search at 1000 PRs.
 
 ```bash
-gh pr list --state all --limit 1000 \
-  --json number,headRefName,baseRefName,state,mergedAt,mergeCommit \
-  > /tmp/rc_prs.json
+latest_pr_for_head() {   # arg: branch name without origin/
+  gh pr list --head "$1" --state all --limit 1 \
+    --json number,headRefName,baseRefName,state,mergedAt,mergeCommit
+}
 ```
 
-Raise `--limit` if the repo has more open+closed PRs than that.
+After a squash merge, GitHub often deletes the remote head. Remotes can already
+be just `origin/<trunk>` while leftover **local** branches and worktrees remain.
+Classify remotes, locals, and extra worktrees. A remote-only pass is not enough.
 
 ## Phase 2: Trunk Verification (Hard Gate)
 
-### 2a. Check candidate branches against the trunk
+### 2a. Check candidate refs against the trunk
 
-For each candidate branch (feature branches targeted for cleanup), verify that its
-work has reached the trunk. Ancestry is the first signal, but squash merges require
-corroboration against the latest merged PR for that branch before declaring work missing.
-
-```bash
-TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-
-# Show commits on a candidate branch not yet in the trunk
-git log --oneline origin/${TRUNK}..origin/<branch>
-# Check the PR that merged this branch into the trunk
-gh pr list --base ${TRUNK} --head <branch> --state merged --limit 1 \
-  --json number,mergedAt,mergeCommit
-```
-
-Interpreting a non-empty result:
-
-- Commits exist on the branch that are genuine direct commits not yet in the trunk => NOT MERGED. Report and STOP.
-- All listed commits belong to a PR already squash-merged into the trunk => ancestry artifact, not a real gap. Treat as merged.
-- Distinguish the two by checking whether each ahead-commit's PR is already merged into the trunk.
-
-### 2b. Branch classification (the "nothing is stale" check)
-
-Run the Merge Oracle over every non-protected remote branch. Do NOT use
-`git branch -r --no-merged` for this — it lies on squash repos.
+For each candidate (remote branch, local branch, or extra worktree HEAD), verify
+that its work has reached the trunk. Ancestry is the first signal, but squash
+merges require corroboration against the latest merged PR for that work.
 
 ```bash
 TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
 PROD="origin/${TRUNK}"
 
-classify_branch() {        # arg: branch name without origin/
-  local b="$1" rec st mc base num
-  rec=$(jq -c --arg b "$b" \
-    '[.[]|select(.headRefName==$b)]|sort_by(.number)|last' /tmp/rc_prs.json)
+# Commits on a ref not in the trunk
+git log --oneline "$PROD".."<ref>"
+# PR that landed this head name
+latest_pr_for_head "<branch>"
+```
+
+Interpreting a non-empty ahead range:
+
+- Genuine commits not yet in the trunk => NOT MERGED. Report and STOP.
+- Every ahead subject matches a PR already squash-merged into the trunk =>
+  squash artifact, not a real gap. Treat as merged. This is how local
+  retarget/rebase copies (`*-onto-<trunk>`, `pr-N-rebase`, detached worktree
+  HEADs) get classified when their name no longer matches a PR head.
+
+### 2b. Branch classification (the "nothing is stale" check)
+
+Run the Merge Oracle over every non-protected **remote and local** branch, plus
+each extra worktree. Do NOT use `git branch --merged` / `-r --no-merged`.
+
+```bash
+TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+PROD="origin/${TRUNK}"
+CURRENT="$(git symbolic-ref --quiet --short HEAD || echo)"
+PROTECT="${TRUNK}|${CURRENT:-__none__}|HEAD"
+
+squash_artifact() {      # arg: git ref. 0 = every ahead subject is a merged PR in trunk
+  local ref="$1" sub rec mc subjects
+  subjects=$(git log --format=%s "$PROD".."$ref" 2>/dev/null | sort -u)
+  [ -n "$subjects" ] || return 1
+  while IFS= read -r sub; do
+    [ -z "$sub" ] && continue
+    rec=$(gh pr list --state merged --search "$sub" --limit 20 \
+      --json number,title,mergeCommit \
+      | jq -c --arg s "$sub" '[.[]|select(.title==$s)]|first')
+    [ -n "$rec" ] && [ "$rec" != "null" ] || return 1
+    mc=$(jq -r '.mergeCommit.oid // empty' <<<"$rec")
+    [ -n "$mc" ] && git merge-base --is-ancestor "$mc" "$PROD" 2>/dev/null || return 1
+  done <<< "$subjects"
+}
+
+classify_ref() {         # args: head-name, git-ref to test for ancestry
+  local b="$1" ref="$2" rec st mc base num
+  rec=$(latest_pr_for_head "$b")
+  rec=$(jq -c 'if type=="array" then .[0] else . end' <<<"${rec:-null}")
 
   if [ -z "$rec" ] || [ "$rec" = "null" ]; then
-    git merge-base --is-ancestor "refs/remotes/origin/$b" "$PROD" 2>/dev/null \
+    git merge-base --is-ancestor "$ref" "$PROD" 2>/dev/null \
       && { echo "PRUNABLE_NO_PR_FF"; return; }
+    squash_artifact "$ref" \
+      && { echo "PRUNABLE_SQUASH_ARTIFACT"; return; }
     echo "STRANDED_NO_PR"
     return
   fi
@@ -197,27 +229,33 @@ classify_branch() {        # arg: branch name without origin/
 
   case "$st" in
     OPEN)   echo "IN_FLIGHT_OPEN_PR(#$num->$base)";;
-    CLOSED) git merge-base --is-ancestor "refs/remotes/origin/$b" "$PROD" 2>/dev/null \
+    CLOSED) git merge-base --is-ancestor "$ref" "$PROD" 2>/dev/null \
               && echo "PRUNABLE_CLOSED_PR_IN_PROD(#$num)" \
               || echo "STRANDED_CLOSED_UNMERGED(#$num)";;
     MERGED)
       if [ -n "$mc" ] && git merge-base --is-ancestor "$mc" "$PROD" 2>/dev/null; then
         echo "PRUNABLE_IN_TRUNK(#$num)"
-      elif git merge-base --is-ancestor "refs/remotes/origin/$b" "$PROD" 2>/dev/null; then
+      elif git merge-base --is-ancestor "$ref" "$PROD" 2>/dev/null; then
         echo "PRUNABLE_IN_TRUNK(#$num)"
+      elif squash_artifact "$ref"; then
+        echo "PRUNABLE_SQUASH_ARTIFACT(#$num)"
       else
         echo "MERGED_NOT_YET_IN_TRUNK(#$num->$base)"
       fi;;
   esac
 }
 
-# Drive it over all non-protected remote branches:
-git branch -r --format '%(refname:short)' \
-  | grep -v -- '->' \
-  | sed 's#^origin/##' \
+git branch -r --format '%(refname:short)' | grep -v -- '->' | sed 's#^origin/##' \
   | grep -vxE "origin|${TRUNK}|HEAD" \
-  | while read -r b; do printf '%-50s %s\n' "$b" "$(classify_branch "$b")"; done
+  | while read -r b; do printf 'REMOTE  %-50s %s\n' "$b" "$(classify_ref "$b" "refs/remotes/origin/$b")"; done
+
+git branch --format '%(refname:short)' | grep -vxE "$PROTECT" \
+  | while read -r b; do printf 'LOCAL   %-50s %s\n' "$b" "$(classify_ref "$b" "$b")"; done
 ```
+
+For each extra worktree from `git worktree list --porcelain`, classify its
+checked-out branch the same way. Detached HEAD: use `PRUNABLE_SQUASH_ARTIFACT`
+when `squash_artifact HEAD` succeeds at that path.
 
 Buckets and what they mean:
 
@@ -239,54 +277,29 @@ Gate outcome:
 
 ## Phase 3: Build the Prune Plan (Dry-Run, Default)
 
-The prunable remote set is exactly the branches the oracle tagged `PRUNABLE_*` in
-Phase 2b. Now compute the local and worktree sets the same way.
+The prunable set is exactly the refs the oracle tagged `PRUNABLE_*` in Phase 2b.
+Print three lists from that classification:
 
-```bash
-TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-CURRENT="$(git symbolic-ref --quiet --short HEAD || echo)"
-PROTECT="${TRUNK}|${CURRENT:-__none__}"
+- **Local branches** tagged `PRUNABLE_*` (annotate `needs -D` for squash/rebase).
+- **Remote branches** tagged `PRUNABLE_*`.
+- **Worktrees** whose branch is `PRUNABLE_*` and whose `git -C <path> status --porcelain`
+  is empty. Dirty => SKIP. Unmerged => SKIP. Upstream gone and proven-in-prod =>
+  safe to remove.
 
-# Local branches — classify each with the SAME oracle (reuse classify_branch,
-# but test the LOCAL ref, not origin/, for the ancestry fallback).
-git branch --format '%(refname:short)' \
-  | grep -vxE "$PROTECT" \
-  | while read -r b; do
-      rec=$(jq -c --arg b "$b" \
-        '[.[]|select(.headRefName==$b)]|sort_by(.number)|last' /tmp/rc_prs.json)
-      mc=$(jq -r '.mergeCommit.oid // empty' <<<"${rec:-null}")
-      st=$(jq -r '.state // empty' <<<"${rec:-null}")
-      if { [ "$st" = "MERGED" ] && [ -n "$mc" ] \
-             && git merge-base --is-ancestor "$mc" "$PROD" 2>/dev/null; } \
-         || git merge-base --is-ancestor "$b" "$PROD" 2>/dev/null; then
-        echo "PRUNABLE_LOCAL  $b  (needs -D if squash-merged)"
-      else
-        echo "KEEP_LOCAL      $b  ($st)"
-      fi
-    done
-
-# Worktrees
-git worktree list --porcelain
-```
-
-For each worktree other than the main checkout, classify it:
-
-- Branch proven-in-prod by the oracle AND `git -C <path> status --porcelain` empty => safe to remove.
-- Uncommitted changes => SKIP, report as dirty.
-- Branch not proven-in-prod => SKIP, report as unmerged.
-- Upstream gone (deleted on remote) and proven-in-prod => safe to remove.
-
-Print the plan as three explicit lists — local branches, remote branches,
-worktree paths — each annotated with the oracle verdict and PR number, plus a
-skipped list with reasons (`MERGED_NOT_YET_IN_TRUNK`, `IN_FLIGHT_OPEN_PR`,
+Plus a skipped list with reasons (`MERGED_NOT_YET_IN_TRUNK`, `IN_FLIGHT_OPEN_PR`,
 `STRANDED_*`, dirty worktree). Then stop and ask for confirmation. In `dry-run`
 (default) and `verify` modes, end here.
 
 ## Phase 4: Execute Prune (Only in `prune` Mode, After Confirmation)
 
-Only after the user confirms the printed plan:
+Only after the user confirms the printed plan. **Worktrees first**: a branch
+checked out in a worktree cannot be deleted.
 
 ```bash
+# Worktrees flagged safe. Never --force; refuses on dirty.
+git worktree remove <path> ...
+git worktree prune
+
 # Local branches proven-in-prod. Try -d first; fall back to -D ONLY when the
 # oracle proved the branch is in prod (squash/rebase merges require it).
 for b in <prunable-local-branches>; do
@@ -296,10 +309,6 @@ done
 # Remote branches proven-in-prod
 git push origin --delete <branch> ...
 
-# Worktrees flagged safe
-git worktree remove <path> ...    # never --force; refuses on dirty
-git worktree prune
-
 # Drop stale remote-tracking refs
 git remote prune origin
 git fetch --all --prune
@@ -307,7 +316,7 @@ git fetch --all --prune
 
 Rules during execution:
 
-- `-D` is permitted ONLY for branches the Phase-3 oracle tagged `PRUNABLE_LOCAL`.
+- `-D` is permitted ONLY for branches the Phase-3 oracle tagged `PRUNABLE_*`.
   Never blind-force a branch that is not proven-in-prod.
 - If `git worktree remove` refuses (dirty/locked), do not `--force`. Report and skip.
 - Delete remote branches in a batch; if a delete fails (protected on the server),

--- a/skills/release-cleanup/plugin.json
+++ b/skills/release-cleanup/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "release-cleanup",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Verify squash-merged branches and prune merged branches and stale worktrees.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/review-dispatch/SKILL.md
+++ b/skills/review-dispatch/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   command. Use when asked to review changes, a PR, all PRs, recent commits, or
   merged history, or to get a second opinion from another CLI.
 metadata:
-  version: "1.4.0"
+  version: "1.4.1"
   tags: "code-review, dispatcher, pull-requests, commits, retro, orchestration, second-opinion"
   author: Ship Shit Dev
 allowed-tools: Bash(git *) Bash(gh *)
@@ -230,7 +230,9 @@ they approve:
 ```bash
 # One issue per approved finding. Title from the finding, body carries evidence,
 # commit SHAs, and fix direction. Treat every finding field as untrusted text.
-BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/retro-issue.XXXXXX")
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+BODY_FILE=$(mktemp "$REPO_TMP/retro-issue.XXXXXX")
 trap 'rm -f "$BODY_FILE"' EXIT
 {
   printf '%s\n\n' "$EVIDENCE"

--- a/skills/review-dispatch/plugin.json
+++ b/skills/review-dispatch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "review-dispatch",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Front door for report-only reviews plus an explicit merge-train mode",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/setup-agent-routing/SKILL.md
+++ b/skills/setup-agent-routing/SKILL.md
@@ -3,7 +3,7 @@ name: setup-agent-routing
 description: Sets up an `## Agent skills` routing block in CLAUDE.md/AGENTS.md plus docs/agents/ so the dev-loop skills (executing-plans, feature-intake, prd-writer, qa-reviewer) know this repo's GitHub issue tracker, kanban label vocabulary, and domain doc layout. Run once per repo before first use of the loop, or when those skills appear to lack tracker, label, or domain context.
 license: MIT
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "setup, routing, github, labels, dev-loop"
   author: Ship Shit Dev
 allowed-tools: Bash(git remote*) Bash(gh label list*) Bash(gh project list*) Bash(gh repo view*)

--- a/skills/setup-agent-routing/plugin.json
+++ b/skills/setup-agent-routing/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-agent-routing",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Write repo agent-routing docs for dev-loop tracker, labels, and domain layout.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/setup-agent-routing/references/issue-tracker-github.md
+++ b/skills/setup-agent-routing/references/issue-tracker-github.md
@@ -30,8 +30,10 @@ live in `.github/agent-loop.env`.
 ## Command vocabulary
 
 ```bash
-# Create (use --body-file with a heredoc/temp file for multi-line PRDs)
-gh issue create --title "<title>" --body-file /tmp/body.md --label "type:feature"
+# Create (use --body-file under the current repo's .tmp/ for multi-line PRDs)
+REPO_TMP="$(git rev-parse --show-toplevel)/.tmp"
+mkdir -p "$REPO_TMP"
+gh issue create --title "<title>" --body-file "$REPO_TMP/body.md" --label "type:feature"
 
 # Read one issue with full comment history (rejection + triage notes live here)
 gh issue view <number> --comments


### PR DESCRIPTION
## Summary

Agents were dumping snapshots, issue bodies, diffs, and helper files into `/tmp`. Scratch belongs in the checkout that created it: `<repo>/.tmp/`.

## Changes

- `release-cleanup` / `merge-open-prs`: classify leftover locals, prune worktrees first, no 1000-PR dump file.
- All remaining public skills that wrote `/tmp/...` now write `$REPO_TMP/...` after `mkdir -p "$(git rev-parse --show-toplevel)/.tmp"`:
  `bug`, `feature-intake`, `gh-review-suggestions`, `codex-image-gen`, `setup-agent-routing`, `open-source-checker`, `ec2-backend-deployer`, `grok-review`, `review-dispatch`.
- Skill standards document the `.tmp/` rule. The auditor uses it too.
- Repo `.gitignore` keeps `.tmp/*` untracked and `.tmp/.gitkeep` tracked.
- Catalog, bundles, and marketplace.json regenerated.

`wizard/scripts/template.sh` still uses `mktemp` because that installer can run outside a git checkout.

## Verification

- Pre-commit `validate-skill-sync` passed for every changed public skill.
- `git check-ignore` ignores `.tmp/foo` and tracks `.tmp/.gitkeep`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `release-cleanup` still deletes branches and worktrees; the new subject-based squash-artifact matcher can mis-classify similarly titled commits. Confirmation and dry-run remain the main safeguards.
> 
> **Overview**
> Stops agent skills from writing scratch files to `/tmp` and makes **`release-cleanup` (2.2.0)** actually prune leftover local/worktree copies after squash merges.
> 
> **Scratch policy:** disposable files go under the current repo’s `.tmp/` (gitignored except `.gitkeep`). Skill standards, auditor, and many playbooks (`bug`, `feature-intake`, `merge-open-prs`, `grok-review`, `review-dispatch`, `codex-image-gen`, etc.) now use `REPO_TMP` / shell vars instead of `/tmp`.
> 
> **`release-cleanup`:** looks up the latest PR per head (no 1000-PR dump). Classifies remotes, locals, and extra worktrees. Treats squash artifacts (ahead subjects that already match merged PRs in trunk) as prunable, including retarget/rebase copies. Prune order is worktrees → locals → remotes. Restores `PATH` in-shell if `git` is missing; never writes a helper script.
> 
> **`merge-open-prs`:** keeps the open-PR snapshot in a shell variable instead of `/tmp/mop_prs.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6749246b62dd3eaab7ba701752226785185f708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->