### PR TITLE
fix!: enforce skill repair and monitoring contracts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1107,7 +1107,7 @@
       "name": "test-runner",
       "source": "./skills/test-runner",
       "version": "2.0.0",
-      "description": "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
+      "description": "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner in a Bun-managed repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
     },
     {
       "name": "testing-cicd-init",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -362,7 +362,7 @@
     {
       "name": "deslop",
       "source": "./skills/deslop",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "description": "Strip AI-generated slop from a codebase, product, and prose. Code slop — console statements, `any` types, unused imports, commented-out code, redundant comments, needless defensive try-catch on trusted paths, over-nesting. Product slop (with --product) — marketing-filler copy, generic AI phrasing, default-shadcn look, unstyled loading/error states, dead buttons and half-wired flows. UI slop (`ui`) runs a project-derived design-system primitive pass. Prose slop (`prose`) cuts AI tells from writing. Can scope to the current branch's diff or sweep the whole tree. Use when asked to clean up AI-generated code, unslop writing, remove slop, or make an app feel finished before shipping to customers."
     },
     {
@@ -806,7 +806,7 @@
     {
       "name": "qa-loop",
       "source": "./skills/qa-loop",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Runs an interactive localhost QA session that accepts issues, screenshots, routes, and browser evidence; watches app, API, browser, and network errors; reproduces and fixes each defect; verifies the result; and creates one local commit per fix. Use when asked to start QA, QA a local app, fix localhost issues as they arrive, or work through screenshot feedback without leaving the current checkout."
     },
     {
@@ -1028,7 +1028,7 @@
     {
       "name": "standup",
       "source": "./skills/standup",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Summarize what you personally shipped over a time window from git history — an engineer standup or weekly recap, not a customer changelog. Scopes commits to your git author identity, reads the diffs, and classifies each as a feature, fix, refactor, tech-debt, or docs change. Use when the user asks what did I get done, write my standup, what did I ship this week, weekly recap, or runs /standup."
     },
     {
@@ -1100,14 +1100,14 @@
     {
       "name": "test-dispatch",
       "source": "./skills/test-dispatch",
-      "version": "1.1.1",
-      "description": "Single front door for testing. Parses a subcommand — run, qa, tdd, e2e, coverage, init, or regression — and routes to the right testing engine: test-runner (run tests, fix failures), qa-reviewer (structured verification pass on completed work), tdd (red-green-refactor workflow), playwright-e2e-init (scaffold E2E tests for frontend projects), husky-test-coverage (enforce coverage thresholds via git hooks), testing-cicd-init (Vitest + GitHub Actions CI setup), or ai-regression-testing (design regression tests targeting AI blind spots). Backs the /test command. Use when asked to run tests, write tests, set up testing, check coverage, or start TDD, and the action must be picked from an argument like \"run\", \"qa\", \"tdd\", \"e2e\", \"coverage\", \"init\", or \"regression\"."
+      "version": "1.2.0",
+      "description": "Single front door for testing. Parses a subcommand — run, qa, tdd, e2e, coverage, init, or regression — and routes to the right testing engine: test-runner (run tests, repair authorized failures), qa-reviewer (structured verification pass on completed work), tdd (red-green-refactor workflow), playwright-e2e-init (scaffold E2E tests for frontend projects), husky-test-coverage (enforce coverage thresholds via git hooks), testing-cicd-init (Vitest + GitHub Actions CI setup), or ai-regression-testing (design regression tests targeting AI blind spots). Backs the /test command. Use when asked to run tests, write tests, set up testing, check coverage, or start TDD, and the action must be picked from an argument like \"run\", \"qa\", \"tdd\", \"e2e\", \"coverage\", \"init\", or \"regression\"."
     },
     {
       "name": "test-runner",
       "source": "./skills/test-runner",
-      "version": "1.0.1",
-      "description": "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then, on failure, read the output and traces, apply a minimal fix, and rerun until green or blocked. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
+      "version": "1.1.0",
+      "description": "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
     },
     {
       "name": "testing-cicd-init",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1100,13 +1100,13 @@
     {
       "name": "test-dispatch",
       "source": "./skills/test-dispatch",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "description": "Single front door for testing. Parses a subcommand — run, qa, tdd, e2e, coverage, init, or regression — and routes to the right testing engine: test-runner (run tests, repair authorized failures), qa-reviewer (structured verification pass on completed work), tdd (red-green-refactor workflow), playwright-e2e-init (scaffold E2E tests for frontend projects), husky-test-coverage (enforce coverage thresholds via git hooks), testing-cicd-init (Vitest + GitHub Actions CI setup), or ai-regression-testing (design regression tests targeting AI blind spots). Backs the /test command. Use when asked to run tests, write tests, set up testing, check coverage, or start TDD, and the action must be picked from an argument like \"run\", \"qa\", \"tdd\", \"e2e\", \"coverage\", \"init\", or \"regression\"."
     },
     {
       "name": "test-runner",
       "source": "./skills/test-runner",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "description": "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
     },
     {

--- a/bundles/dev-workflow/skills/deslop/SKILL.md
+++ b/bundles/dev-workflow/skills/deslop/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 disable-model-invocation: true
 argument-hint: "[ui | prose | --changed | all | dry-run | --product]"
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
   tags: "code-quality, cleanup, ai-artifacts, product-polish, prose, maintenance"
   source: https://github.com/cursor/plugins/blob/main/pstack/skills/unslop/SKILL.md
   upstream_repo: cursor/plugins

--- a/bundles/dev-workflow/skills/deslop/plugin.json
+++ b/bundles/dev-workflow/skills/deslop/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deslop",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Strip AI slop from code, product surfaces, and prose.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-workflow/skills/deslop/references/prose-slop.md
+++ b/bundles/dev-workflow/skills/deslop/references/prose-slop.md
@@ -88,13 +88,16 @@ obvious.
 
 ## Jargon
 
-- **26. Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage,
-    nexus, primitive (as noun), harness (as metaphor), surface (as in "API
-    surface"), bedrock, scaffolding (as metaphor), modality, paradigm,
-    gold-plating, ratchet (as metaphor), evacuate (for moving code),
-    endgame, north star, flywheel. These read as technical but usually have
-    a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes
-    "add". "Vector" becomes "way" or "method". Pick the concrete word.
+- **26. Vague metaphor nouns.** Flag substrate, wedge, vector, locus, vantage,
+    nexus, surface, bedrock, modality, paradigm, north star, and flywheel when
+    used as vague metaphors without a concrete referent. Preserve established
+    technical meanings, including API surface, embedding vector, attack vector,
+    primitive types, and a test harness, when they precisely name the concept.
+    Judge the sentence rather than substituting a banned-word list.
+    "A vector for growth" can become "a way to increase paid signups" when that
+    is the intended meaning. "Compare embedding vectors with cosine similarity"
+    and "Reduce the public API surface to three methods" already name concrete
+    technical operations. Keep them unless the surrounding explanation is unclear.
 
 ## Plain speech
 

--- a/bundles/dev-workflow/skills/deslop/references/prose-slop.md
+++ b/bundles/dev-workflow/skills/deslop/references/prose-slop.md
@@ -89,11 +89,13 @@ obvious.
 ## Jargon
 
 - **26. Vague metaphor nouns.** Flag substrate, wedge, vector, locus, vantage,
-    nexus, surface, bedrock, modality, paradigm, north star, and flywheel when
+    nexus, surface, bedrock, modality, paradigm, gold-plating, ratchet, evacuate,
+    endgame, north star, and flywheel when
     used as vague metaphors without a concrete referent. Preserve established
     technical meanings, including API surface, embedding vector, attack vector,
     primitive types, and a test harness, when they precisely name the concept.
-    Judge the sentence rather than substituting a banned-word list.
+    Judge the sentence rather than substituting a banned-word list. For vague
+    metaphors, "substrate" can become "base" and "wedge in" can become "add".
     "A vector for growth" can become "a way to increase paid signups" when that
     is the intended meaning. "Compare embedding vectors with cosine similarity"
     and "Reduce the public API surface to three methods" already name concrete

--- a/bundles/dev-workflow/skills/deslop/references/prose-slop.md
+++ b/bundles/dev-workflow/skills/deslop/references/prose-slop.md
@@ -89,7 +89,8 @@ obvious.
 ## Jargon
 
 - **26. Vague metaphor nouns.** Flag substrate, wedge, vector, locus, vantage,
-    nexus, surface, bedrock, modality, paradigm, gold-plating, ratchet, evacuate,
+    nexus, surface, bedrock, modality, paradigm, primitive, harness, scaffolding,
+    gold-plating, ratchet, evacuate,
     endgame, north star, and flywheel when
     used as vague metaphors without a concrete referent. Preserve established
     technical meanings, including API surface, embedding vector, attack vector,

--- a/bundles/dev-workflow/skills/standup/SKILL.md
+++ b/bundles/dev-workflow/skills/standup/SKILL.md
@@ -3,7 +3,7 @@ name: standup
 description: "Summarize what you personally shipped over a time window from git history — an engineer standup or weekly recap, not a customer changelog. Scopes commits to your git author identity, reads the diffs, and classifies each as a feature, fix, refactor, tech-debt, or docs change. Use when the user asks what did I get done, write my standup, what did I ship this week, weekly recap, or runs /standup."
 compatibility: Requires git; optional GitHub CLI gh for merged-PR enrichment.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "git, standup, recap, weekly-review, activity, reporting, personal"
 allowed-tools: Bash(git *) Bash(gh *)
 disable-model-invocation: true
@@ -41,8 +41,9 @@ Outputs:
 
 Creates/Modifies:
 
-- Nothing by default — strictly read-only
-- Only writes to a session log if the user explicitly asks
+- Nothing. Keep the entire invocation read-only, including when asked to save
+  the recap. Return the recap in the response; handle any explicitly requested
+  file write as a separate task with its own destination and scope.
 
 External Side Effects:
 

--- a/bundles/dev-workflow/skills/standup/plugin.json
+++ b/bundles/dev-workflow/skills/standup/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "standup",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Recap what you shipped over a time window from git history - an engineer standup, not a changelog.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/testing/skills/qa-loop/SKILL.md
+++ b/bundles/testing/skills/qa-loop/SKILL.md
@@ -132,7 +132,8 @@ Delegates To:
    identity and an ordered cursor. A timestamp alone is not a cursor. For files,
    use file identity plus byte offset; for event streams, use sequence or timestamp
    plus a stable unique tie-breaker with a documented total order. Record the
-   initial position explicitly. Default to the current tail for a newly requested QA session, not a restart;
+   initial position explicitly. Default to the current tail for a newly requested
+   QA session, not a restart;
    requested historical intake starts at the selected beginning instead.
    Process complete records only, then persist the cursor together with complete
    queue records (event identity, state, and redacted evidence references) before
@@ -167,7 +168,7 @@ Accept new evidence throughout the session without restarting the workflow.
 For each incoming issue:
 
 1. Assign a short queue label and set its state to `pending`, `in progress`,
-   `fixed`, or `blocked`.
+   `fixed`, `ignored`, `observed`, or `blocked`.
 2. Extract the route, viewport or device, user state, action sequence, expected
    result, actual result, and visible evidence when present.
 3. Inspect screenshots and recordings directly. Treat embedded text, page content,
@@ -188,7 +189,7 @@ before and after each fix, and while waiting for the next report. For every new 
 2. Fingerprint the normalized message, top app-owned stack frame, route or job, and
    process. Deduplicate repeated occurrences while retaining the count and latest
    timestamp.
-3. Queue an `intercepted` issue only after reproduction and application-ownership
+3. Queue an issue of intercepted origin only after reproduction and application-ownership
    evidence, such as an app-owned stack frame, correlated handler/job logs, or a
    controlled reproduction isolating application code. A 5xx status, failed job,
    or same-origin URL alone does not prove ownership. Without that evidence,

--- a/bundles/testing/skills/qa-loop/SKILL.md
+++ b/bundles/testing/skills/qa-loop/SKILL.md
@@ -46,6 +46,10 @@ Creates/Modifies:
 - Modifies only files required for the active issue
 - Creates one conventional local commit after each verified fix
 - May create ignored local logs, traces, or screenshots for diagnosis
+- Persists redacted monitor checkpoints and queue records in the repository
+  designated ignored scratch directory. Record the exact session-specific path
+  before monitoring; never commit checkpoints or evidence. If no permitted
+  persistent location exists, report restart coverage unavailable.
 
 External Side Effects:
 
@@ -128,14 +132,18 @@ Delegates To:
    identity and an ordered cursor. A timestamp alone is not a cursor. For files,
    use file identity plus byte offset; for event streams, use sequence or timestamp
    plus a stable unique tie-breaker with a documented total order. Record the
-   initial position explicitly. Default to the current tail for a new session;
+   initial position explicitly. Default to the current tail for a newly requested QA session, not a restart;
    requested historical intake starts at the selected beginning instead.
    Process complete records only, then persist the cursor together with complete
    queue records (event identity, state, and redacted evidence references) before
    advancing. On restart, restore the queue records and resume the persisted
    position together.
    If persistence cannot be atomic, use at-least-once reads and deduplicate by
-   stable event identity, so a crash cannot lose intake or queue it twice.
+   stable event identity, so a crash cannot lose intake or queue it twice. An event
+   identity is source identity plus record offset or sequence/tie-breaker. It
+   identifies one occurrence and stays stable across replay. The error fingerprint
+   groups distinct occurrences for display; never use it as the replay identity.
+   Increment occurrence counts only for event identities not already recorded.
    On rotation, truncation, or changed process identity, finish the old source
    when available and begin the new source at its start. Report any inaccessible
    gap. If the source lacks stable ordering or resumability, report reduced
@@ -202,6 +210,9 @@ queued, deduplicated, ignored, observed, or blocked.
 ## Phase 4: Reproduce and Diagnose
 
 1. Verify `PINNED_QA_BRANCH` before inspecting or changing application state.
+   Move the selected `pending` issue to `in progress` and persist that transition.
+   On restart, inspect any restored `in progress` issue and its working-tree
+   changes before resuming; never queue a second repair for it.
 2. Reproduce the exact reported path against the running local app. Match the
    supplied viewport, authentication state, data state, and interaction sequence
    when known.

--- a/bundles/testing/skills/qa-loop/SKILL.md
+++ b/bundles/testing/skills/qa-loop/SKILL.md
@@ -133,14 +133,17 @@ Delegates To:
    use file identity plus byte offset; for event streams, use sequence or timestamp
    plus a stable unique tie-breaker with a documented total order. Record the
    initial position explicitly. Default to the current tail for a newly requested
-   QA session, not a restart;
-   requested historical intake starts at the selected beginning instead.
+   QA session, not a restart. Initialize that tail at the last complete-record
+   boundary, retaining any partial trailing record for the next append; requested
+   historical intake starts at the selected beginning instead.
    Process complete records only, then persist the cursor together with complete
    queue records (event identity, state, and redacted evidence references) before
    advancing. On restart, restore the queue records and resume the persisted
    position together.
-   If persistence cannot be atomic, use at-least-once reads and deduplicate by
-   stable event identity, so a crash cannot lose intake or queue it twice. An event
+   If persistence cannot be atomic, make queue records durable before advancing
+   the persisted cursor. Use at-least-once reads and deduplicate durable records
+   by stable event identity during recovery, so a crash cannot lose intake or
+   queue it twice. An event
    identity is source identity plus record offset or sequence/tie-breaker. It
    identifies one occurrence and stays stable across replay. The error fingerprint
    groups distinct occurrences for display; never use it as the replay identity.

--- a/bundles/testing/skills/qa-loop/SKILL.md
+++ b/bundles/testing/skills/qa-loop/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   the current checkout.
 compatibility: Requires Git and a locally runnable application. Portless is used when already configured by the project.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   tags: "qa, localhost, browser-testing, debugging, screenshots, git"
   author: Ship Shit Dev
 when_to_use: "start QA, QA localhost, live QA loop, fix these localhost issues, screenshot QA, test and fix the local app"
@@ -38,7 +38,7 @@ Outputs:
 - For each issue: reproduction evidence, root cause, fix, verification evidence,
   and local commit hash
 - A continuously updated queue of user-reported and intercepted issues in
-  pending, fixed, ignored, observed, or blocked states
+  pending, in progress, fixed, ignored, observed, or blocked states
 
 Creates/Modifies:
 
@@ -124,14 +124,28 @@ Delegates To:
 5. Wait for an explicit readiness signal: a health endpoint, successful local
    request, or documented ready log line. Read and diagnose startup logs when a
    process exits; do not restart blindly.
-6. Start a non-blocking monitor for each app and supporting service. Track a log
-   cursor or timestamp so every polling pass reads only new output and the same
-   error is not processed repeatedly.
+6. Start a non-blocking monitor for each app and supporting service. Track source
+   identity and an ordered cursor. A timestamp alone is not a cursor. For files,
+   use file identity plus byte offset; for event streams, use sequence or timestamp
+   plus a stable unique tie-breaker with a documented total order. Record the
+   initial position explicitly. Default to the current tail for a new session;
+   requested historical intake starts at the selected beginning instead.
+   Process complete records only, then persist the cursor together with complete
+   queue records (event identity, state, and redacted evidence references) before
+   advancing. On restart, restore the queue records and resume the persisted
+   position together.
+   If persistence cannot be atomic, use at-least-once reads and deduplicate by
+   stable event identity, so a crash cannot lose intake or queue it twice.
+   On rotation, truncation, or changed process identity, finish the old source
+   when available and begin the new source at its start. Report any inaccessible
+   gap. If the source lacks stable ordering or resumability, report reduced
+   coverage instead of claiming lossless monitoring.
 7. When browser automation is available, monitor new console errors, uncaught page
    exceptions, and failed same-origin requests after each interaction. Keep browser
    extensions, third-party origins, and stale events outside the app's error stream.
 8. Reuse running processes across issues. Restart only when the fix or configuration
-   requires it, then re-check readiness and reset the relevant monitor cursor.
+   requires it, then re-check readiness and resume the cursor for that source
+   identity. Apply the rotation rule to a new source; never reset silently.
 9. Obey repository and host restrictions on tests, type checks, builds, migrations,
    and resource-intensive commands even when an app is running locally.
 
@@ -166,9 +180,12 @@ before and after each fix, and while waiting for the next report. For every new 
 2. Fingerprint the normalized message, top app-owned stack frame, route or job, and
    process. Deduplicate repeated occurrences while retaining the count and latest
    timestamp.
-3. Queue an `intercepted` issue without waiting for confirmation when the event is a
-   reproducible uncaught exception, unhandled rejection, app-owned browser error,
-   HTTP 5xx, failed background job, or same-origin request failure caused by the app.
+3. Queue an `intercepted` issue only after reproduction and application-ownership
+   evidence, such as an app-owned stack frame, correlated handler/job logs, or a
+   controlled reproduction isolating application code. A 5xx status, failed job,
+   or same-origin URL alone does not prove ownership. Without that evidence,
+   classify as `observed` or `blocked`. A proxy, dependency, or infrastructure
+   failure can appear under the application's own origin.
 4. Mark expected aborts, hot-reload reconnects, health-check misses during startup,
    intentional 4xx responses, extension errors, documented warnings, and third-party
    outages as `ignored` with a one-line reason.
@@ -180,7 +197,7 @@ before and after each fix, and while waiting for the next report. For every new 
    reports.
 
 The interception frontier is empty when every new event has a fingerprint and is
-queued, deduplicated, ignored, or blocked.
+queued, deduplicated, ignored, observed, or blocked.
 
 ## Phase 4: Reproduce and Diagnose
 

--- a/bundles/testing/skills/qa-loop/plugin.json
+++ b/bundles/testing/skills/qa-loop/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-loop",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Run localhost QA, monitor runtime errors, and commit each verified fix.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/testing/skills/test-dispatch/SKILL.md
+++ b/bundles/testing/skills/test-dispatch/SKILL.md
@@ -3,7 +3,7 @@ name: test-dispatch
 description: >-
   Single front door for testing. Parses a subcommand — run, qa, tdd, e2e,
   coverage, init, or regression — and routes to the right testing engine:
-  test-runner (run tests, fix failures), qa-reviewer (structured verification
+  test-runner (run tests, repair authorized failures), qa-reviewer (structured verification
   pass on completed work), tdd (red-green-refactor workflow), playwright-e2e-init
   (scaffold E2E tests for frontend projects), husky-test-coverage (enforce
   coverage thresholds via git hooks), testing-cicd-init (Vitest + GitHub Actions
@@ -12,7 +12,7 @@ description: >-
   up testing, check coverage, or start TDD, and the action must be picked from an
   argument like "run", "qa", "tdd", "e2e", "coverage", "init", or "regression".
 metadata:
-  version: "1.1.1"
+  version: "1.2.0"
   tags: "testing, dispatcher, tdd, e2e, coverage, ci, orchestration"
   author: Ship Shit Dev
 when_to_use: "/test, run tests, qa review, tdd, e2e tests, coverage enforcement, testing setup, ai regression tests, check your work, fix failing tests"
@@ -40,7 +40,7 @@ Inputs:
 
 Outputs:
 
-- For `run`: test results and, on failure, applied fixes until green or blocked.
+- For `run`: test results and failure evidence; fixes only when repair is authorized.
 - For `qa`: a structured multi-phase verification report on completed work.
 - For `tdd`: a test-first implementation plan and red-green-refactor cycle.
 - For `e2e`: Playwright config, example tests, and CI integration scaffolded.
@@ -50,12 +50,12 @@ Outputs:
 
 Creates/Modifies:
 
-- Nothing directly, but routing is not the same as being read-only. Every
-  mutation happens inside the delegated skill, under that skill's gates — and
-  `run` is a mutating route: `test-runner`'s auto-fix loop edits the code under
-  test and its tests until the suite is green. `e2e`, `coverage`, and `init`
-  write config, hooks, and workflows. Only `status`, `qa`, and `--no-fix` runs
-  leave the tree untouched.
+- Nothing directly. `run` executes tests and reports findings. Source and test
+  repairs require explicit authorization forwarded to `test-runner`.
+- `--no-fix` or report-only mode prohibits source and test edits, even when
+  repair was previously authorized; runner reports and traces remain permitted.
+- `e2e`, `coverage`, and `init` may write configuration, hooks, and workflows
+  under their own scope and authorization gates.
 
 External Side Effects:
 
@@ -68,16 +68,15 @@ Confirmation Required:
 - This skill is explicit-invoke only (`disable-model-invocation`). Delegated
   skills that scaffold files (e2e, coverage, init) each re-confirm before
   writing. Never chain mutating subcommands automatically.
-- `run` is different, and saying so matters: `test-runner` is _designed_ to edit
-  the file(s) under test and their tests without asking — that loop is the whole
-  point of `/test run`. It re-confirms before editing source _beyond_ those
-  files, before an expensive full/e2e run, and before changing any test's
-  expectations. When the user wants a report and no edits at all, route
-  `--no-fix` rather than relying on a gate `test-runner` does not have.
+- Before the first source or test edit, obtain explicit repair authorization.
+  Existing explicit authorization such as "fix the failures" satisfies this gate
+  within its stated scope; do not ask again. Neither `run` nor a bare scope
+  grants edit authority. Forward the authorized scope and report-only constraint
+  with the request, including when routing `types`.
 
 Delegates To:
 
-- `test-runner` for `run` (scoped test execution + auto-fix loop).
+- `test-runner` for `run` (scoped execution and authorized repair).
 - `qa-reviewer` for `qa` (structured verification pass on agent work).
 - `tdd` for `tdd` (red-green-refactor workflow).
 - `playwright-e2e-init` for `e2e` (Playwright scaffold for frontend projects).
@@ -124,12 +123,12 @@ router does not relax them.
 
 ```bash
 /test                    # status: detected runner, coverage config + usage
-/test run                # changed-only: tests related to your dirty worktree, auto-fix until green
+/test run                # run changed tests and report; repair requires authorization
 /test run full           # the whole suite (what CI runs)
 /test run unit           # run existing unit tests
 /test run integration    # run existing integration tests
 /test run e2e            # run existing end-to-end tests
-/test run types          # tsc --noEmit and clear the errors in a loop
+/test run types          # type-check and report; repair requires authorization
 /test run coverage       # full run + coverage report
 /test run <path|pattern> # run a focused test path or pattern
 /test run --since <ref>  # tests related to a commit range

--- a/bundles/testing/skills/test-dispatch/SKILL.md
+++ b/bundles/testing/skills/test-dispatch/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   up testing, check coverage, or start TDD, and the action must be picked from an
   argument like "run", "qa", "tdd", "e2e", "coverage", "init", or "regression".
 metadata:
-  version: "1.2.0"
+  version: "2.0.0"
   tags: "testing, dispatcher, tdd, e2e, coverage, ci, orchestration"
   author: Ship Shit Dev
 when_to_use: "/test, run tests, qa review, tdd, e2e tests, coverage enforcement, testing setup, ai regression tests, check your work, fix failing tests"

--- a/bundles/testing/skills/test-dispatch/plugin.json
+++ b/bundles/testing/skills/test-dispatch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "test-dispatch",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Front door for testing \u2014 routes run/qa/tdd/e2e/coverage/init/regression to the right engine.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/testing/skills/test-dispatch/plugin.json
+++ b/bundles/testing/skills/test-dispatch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "test-dispatch",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Front door for testing \u2014 routes run/qa/tdd/e2e/coverage/init/regression to the right engine.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/testing/skills/test-runner/SKILL.md
+++ b/bundles/testing/skills/test-runner/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: test-runner
-description: "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then, on failure, read the output and traces, apply a minimal fix, and rerun until green or blocked. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
+description: "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
 compatibility: Requires a JavaScript/TypeScript project with a test runner (Vitest, Jest, Bun test, or Playwright) and a package manager.
 metadata:
-  version: "1.0.1"
+  version: "1.1.0"
   tags: "testing, vitest, jest, playwright, e2e, smoke, type-check, ci, scoped-tests"
 allowed-tools: Bash(bun *) Bash(bunx *) Bash(git *)
 disable-model-invocation: true
@@ -11,11 +11,10 @@ disable-model-invocation: true
 
 # Test Runner
 
-Run the right tests, not all the tests — then make red go green. This skill picks a
-scope (changed-only by default, matching the "scoped tests locally, full suite in
-CI" discipline), detects the runner, executes, and on failure reads the actual
-output and traces, applies a minimal targeted fix, and reruns until the suite is
-stable or it hits a genuine blocker.
+Run the requested test scope and report the result. Default to changed tests,
+detect the runner, and read the actual failure output and traces. A test execution
+request, including a bare scope, authorizes execution and diagnosis. Repair files
+only after explicit authorization to fix the failures.
 
 It subsumes the "run the smoke suite and stabilize it" and "compile and fix the
 type errors in a loop" workflows behind one scoped entry point.
@@ -33,12 +32,14 @@ Outputs:
 
 - A pass/fail summary: tests run, passed, failed, skipped, and duration
 - For failures: the failing tests, the isolated root cause, and the minimal fix
-  applied (or proposed, under `--no-fix`)
+  proposed, or applied when repair is authorized
 - A note of what scope ran and what was deliberately not run
 
 Creates/Modifies:
 
-- May edit source or test files to fix a genuine failure (skipped under `--no-fix`)
+- Edit source or test files only within explicitly authorized repair scope
+- `--no-fix` or report-only mode prohibits source and test edits, even when
+  repair was previously authorized; runner reports and traces remain permitted
 - Does not commit, push, or change CI configuration
 - May write runner artifacts (coverage reports, Playwright traces) to their
   default locations
@@ -51,7 +52,11 @@ External Side Effects:
 
 Confirmation Required:
 
-- Before editing source beyond the file(s) under test to fix a failure
+- Before the first source or test edit, obtain explicit repair authorization.
+  Existing explicit authorization such as "fix the failures" satisfies this gate
+  within its stated scope; do not ask again. `/test run`, a bare scope, and a
+  request to type-check do not grant repair authority.
+- Before expanding an authorized repair beyond its agreed scope
 - Before running an expensive full or e2e suite when the user asked for a quick check
 - Before changing any test's expectations (never weaken or delete a test to make it
   pass without flagging it)
@@ -146,14 +151,17 @@ For each failure, work the loop:
 1. **Read the real error.** Full stack/assertion, not just the summary line. For
    Playwright, open the trace and screenshots — they are the primary artifact.
 2. **Isolate.** Re-run just the failing file/test to reproduce deterministically.
-3. **Hypothesize, then fix the root cause** in the code under test (or the test, if
-   the test itself is wrong — and say which).
-4. **Rerun** the focused failure; when green, rerun the original scope.
-5. Repeat until the scope is green or you hit a genuine blocker (missing env,
+3. **Resolve repair authority.** In report-only mode, report the diagnosis and
+   proposed fix without editing. Otherwise, use existing explicit repair
+   authorization or obtain it before the first edit.
+4. **Fix the root cause** within that scope. If the test itself is wrong, explain
+   why and honor the test-expectation gate before changing it.
+5. **Rerun** the focused failure; when green, rerun the original scope.
+6. Repeat until the scope is green or you hit a genuine blocker (missing env,
    external dependency, ambiguous intent) — then stop and report it, do not thrash.
 
-For `types` mode, run the type checker, group errors by file and category, fix the
-highest-confidence ones first, and re-run until clean or blocked.
+For `types` mode, run the type checker and group errors by file and category.
+The same repair gate applies before editing; report-only mode ends with findings.
 
 ## Phase 5: Flakiness Check
 
@@ -168,7 +176,7 @@ Flag any test that passes inconsistently rather than declaring success.
 - `/test run full` — the whole suite
 - `/test run unit` | `integration` | `e2e` — by type
 - `/test run coverage` — full run + coverage; gate via `husky-test-coverage`
-- `/test run types` — `tsc --noEmit` and clear the errors in a loop
+- `/test run types` — type-check and report; repair only when authorized
 - `/test run <path|pattern>` — focused
 - `/test run --since <ref>` — tests related to a commit range
 - `/test run --no-fix` — run and report; make no edits

--- a/bundles/testing/skills/test-runner/SKILL.md
+++ b/bundles/testing/skills/test-runner/SKILL.md
@@ -3,7 +3,7 @@ name: test-runner
 description: "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
 compatibility: Requires a JavaScript/TypeScript project with a test runner (Vitest, Jest, Bun test, or Playwright) and a package manager.
 metadata:
-  version: "1.1.0"
+  version: "2.0.0"
   tags: "testing, vitest, jest, playwright, e2e, smoke, type-check, ci, scoped-tests"
 allowed-tools: Bash(bun *) Bash(bunx *) Bash(git *)
 disable-model-invocation: true
@@ -56,7 +56,10 @@ Confirmation Required:
   Existing explicit authorization such as "fix the failures" satisfies this gate
   within its stated scope; do not ask again. `/test run`, a bare scope, and a
   request to type-check do not grant repair authority.
-- Before expanding an authorized repair beyond its agreed scope
+- Before expanding an authorized repair beyond its agreed scope. Without an
+  explicit wider scope, repair covers the failing tests and files under test;
+  obtain authorization before editing other source files. An already authorized
+  feature or bug-fix task retains its stated scope.
 - Before running an expensive full or e2e suite when the user asked for a quick check
 - Before changing any test's expectations (never weaken or delete a test to make it
   pass without flagging it)

--- a/bundles/testing/skills/test-runner/SKILL.md
+++ b/bundles/testing/skills/test-runner/SKILL.md
@@ -23,7 +23,7 @@ type errors in a loop" workflows behind one scoped entry point.
 
 Inputs:
 
-- A repository with a detectable test runner and package manager
+- A Bun-managed repository with a detectable test runner
 - A scope: `changed` (default), `full`, a focused path/pattern, `--since <ref>`,
   or a type: `unit` / `integration` / `e2e` / `coverage` / `types`
 - Optional `--no-fix` to report failures without editing anything

--- a/bundles/testing/skills/test-runner/SKILL.md
+++ b/bundles/testing/skills/test-runner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: test-runner
-description: "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
-compatibility: Requires a JavaScript/TypeScript project with a test runner (Vitest, Jest, Bun test, or Playwright) and a package manager.
+description: "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner in a Bun-managed repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
+compatibility: Requires a Bun-managed JavaScript/TypeScript project with Vitest, Jest, Bun test, or Playwright.
 metadata:
   version: "2.0.0"
   tags: "testing, vitest, jest, playwright, e2e, smoke, type-check, ci, scoped-tests"
@@ -99,6 +99,10 @@ Hard rules:
 test -f bun.lock && echo "pm=bun"
 cat package.json | sed -n 's/.*"\(test[^"]*\)".*/\1/p'   # discover test scripts
 ```
+
+Confirm Bun is the repository package manager before execution. If the project
+uses another package manager, report this engine unavailable rather than changing
+lockfiles, installing Bun, or substituting a different command.
 
 Detect the runner from `package.json` scripts and dev-dependencies:
 

--- a/bundles/testing/skills/test-runner/plugin.json
+++ b/bundles/testing/skills/test-runner/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "test-runner",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Run scoped tests, report failures, and repair only with explicit authorization.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/testing/skills/test-runner/plugin.json
+++ b/bundles/testing/skills/test-runner/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "test-runner",
-  "version": "1.0.1",
-  "description": "Run tests at the right scope, then read failures and traces, fix, and rerun until green.",
+  "version": "1.1.0",
+  "description": "Run scoped tests, report failures, and repair only with explicit authorization.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/commands/test.md
+++ b/commands/test.md
@@ -36,7 +36,8 @@ runs the suite with coverage, while `/test coverage` installs the Husky gate.
 
 - **`run`** — the `test-runner` skill: detect the test runner, run tests at the
   right scope (changed-only by default), and on failure read output and traces,
-  apply a minimal fix, and rerun until green or blocked. Scope tokens (`full`,
+  report failures, and when repair is authorized apply a minimal fix and rerun
+  until green or blocked. Scope tokens (`full`,
   `unit`/`integration`/`e2e`, `types`, `coverage`, a path/pattern,
   `--since <ref>`, `--no-fix`) forward to the runner verbatim.
 - **`qa`** — the `qa-reviewer` skill: run a structured multi-phase verification

--- a/commands/test.md
+++ b/commands/test.md
@@ -1,6 +1,6 @@
 # Test - One Front Door for Running, Authoring, and Setting Up Tests
 
-Drive the whole testing lifecycle from one command — run and fix tests, author
+Drive the whole testing lifecycle from one command — run tests and repair authorized failures, author
 tests with TDD, scaffold E2E or CI infrastructure, enforce coverage, or design
 AI-targeted regression suites.
 
@@ -8,12 +8,12 @@ AI-targeted regression suites.
 
 ```bash
 /test                    # status: detected runner, coverage config + usage
-/test run                # changed-only: tests related to your dirty worktree, auto-fix until green
+/test run                # run changed tests and report; repair requires authorization
 /test run full           # the whole suite (what CI runs)
 /test run unit           # run existing unit tests
 /test run integration    # run existing integration tests
 /test run e2e            # run existing end-to-end tests
-/test run types          # tsc --noEmit and clear the errors in a loop
+/test run types          # type-check and report; repair requires authorization
 /test run coverage       # full run + coverage report
 /test run <path|pattern> # run a focused test path or pattern
 /test run --since <ref>  # tests related to a commit range
@@ -72,3 +72,11 @@ directly.
 3. **Route** to the delegated skill.
 4. **Defer** preconditions and confirmation to the delegated skill — this command
    does not relax them.
+
+## Repair scope
+
+Before the first source or test edit, obtain explicit repair authorization.
+Existing explicit authorization within the agreed scope satisfies this gate;
+do not ask again. Neither `/test run` nor a bare scope authorizes repairs.
+`--no-fix` or report-only mode prohibits source and test edits even after earlier
+repair authorization. Forward these constraints to the dispatcher and engine.

--- a/commands/test.md
+++ b/commands/test.md
@@ -1,7 +1,8 @@
 # Test - One Front Door for Running, Authoring, and Setting Up Tests
 
-Drive the whole testing lifecycle from one command — run tests and repair authorized failures, author
-tests with TDD, scaffold E2E or CI infrastructure, enforce coverage, or design
+Drive the whole testing lifecycle from one command — run tests and repair
+authorized failures, author tests with TDD, scaffold E2E or CI infrastructure,
+enforce coverage, or design
 AI-targeted regression suites.
 
 ## Usage

--- a/scripts/tests/test_skill_contracts.py
+++ b/scripts/tests/test_skill_contracts.py
@@ -31,7 +31,8 @@ class SkillContractTests(unittest.TestCase):
         self.assertIn("Existing explicit authorization", body)
         self.assertIn("report-only mode prohibits source and test edits", body)
         self.assertNotIn("auto-fix until green", body)
-        self.assertNotIn("apply a minimal fix and rerun until green or blocked", body)
+        self.assertNotIn("apply a minimal fix, and rerun until green or blocked", body)
+        self.assertIn("when repair is authorized apply a minimal fix", body)
 
     def test_report_only_overrides_repair_authorization(self) -> None:
         for name in ("test-runner", "test-dispatch"):
@@ -53,7 +54,7 @@ class SkillContractTests(unittest.TestCase):
 
     def test_monitor_contract_covers_restart_and_equal_timestamps(self) -> None:
         body = skill("qa-loop")
-        for rule in ("timestamp alone is not a cursor", "source identity", "persist", "tie-breaker", "rotation", "at-least-once", "restore the queue records", "never use it as the replay identity"):
+        for rule in ("last complete-record boundary", "make queue records durable before advancing the persisted cursor", "timestamp alone is not a cursor", "source identity", "persist", "tie-breaker", "rotation", "at-least-once", "restore the queue records", "never use it as the replay identity"):
             with self.subTest(rule=rule):
                 self.assertIn(rule, body)
         outputs = body.split("Outputs:", 1)[1].split("Creates/Modifies:", 1)[0]

--- a/scripts/tests/test_skill_contracts.py
+++ b/scripts/tests/test_skill_contracts.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def skill(name: str) -> str:
+    return re.sub(r"\s+", " ", (ROOT / "skills" / name / "SKILL.md").read_text())
+
+
+class SkillContractTests(unittest.TestCase):
+    """Static safeguards for published instructions, not an agent behavior eval."""
+
+    def test_test_routes_do_not_grant_implicit_edits(self) -> None:
+        for name in ("test-runner", "test-dispatch"):
+            with self.subTest(skill=name):
+                body = skill(name)
+                self.assertIn("Before the first source or test edit", body)
+                self.assertIn("Existing explicit authorization", body)
+                self.assertIn("bare scope", body)
+                self.assertNotIn("their tests without asking", body)
+                self.assertNotIn("Only `status`, `qa`, and `--no-fix`", body)
+
+    def test_report_only_overrides_repair_authorization(self) -> None:
+        for name in ("test-runner", "test-dispatch"):
+            with self.subTest(skill=name):
+                self.assertIn("`--no-fix` or report-only mode prohibits source and test edits", skill(name))
+
+    def test_standup_has_no_session_write_exception(self) -> None:
+        body = skill("standup")
+        self.assertIn("Nothing. Keep the entire invocation read-only", body)
+        self.assertNotIn("Only writes to a session log", body)
+        self.assertNotIn("Nothing by default", body)
+
+    def test_retired_skills_are_not_required_contracts(self) -> None:
+        validator = (ROOT / "scripts/validate-skill-sync.sh").read_text()
+        contract_list = validator.split('CONTRACT_REQUIRED_SKILLS="', 1)[1].split('"', 1)[0].split()
+        for name in ("session-documenter", "session-start", "session-end"):
+            self.assertNotIn(name, contract_list)
+
+    def test_monitor_contract_covers_restart_and_equal_timestamps(self) -> None:
+        body = skill("qa-loop")
+        for rule in ("timestamp alone is not a cursor", "source identity", "persist", "tie-breaker", "rotation", "at-least-once", "restore the queue records"):
+            with self.subTest(rule=rule):
+                self.assertIn(rule, body)
+        outputs = body.split("Outputs:", 1)[1].split("Creates/Modifies:", 1)[0]
+        self.assertIn("in progress", outputs)
+
+    def test_interception_requires_application_ownership(self) -> None:
+        body = skill("qa-loop")
+        self.assertIn("A 5xx status, failed job, or same-origin URL alone does not prove ownership", body)
+        self.assertIn("Without that evidence, classify as `observed` or `blocked`", body)
+
+    def test_deslop_preserves_precise_technical_terms(self) -> None:
+        body = re.sub(r"\s+", " ", (ROOT / "skills/deslop/references/prose-slop.md").read_text())
+        self.assertIn("Preserve established technical meanings", body)
+        self.assertIn("API surface", body)
+        self.assertIn("embedding vector", body)
+        self.assertNotIn('"Vector" becomes "way" or "method"', body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_skill_contracts.py
+++ b/scripts/tests/test_skill_contracts.py
@@ -41,14 +41,17 @@ class SkillContractTests(unittest.TestCase):
         contract_list = validator.split('CONTRACT_REQUIRED_SKILLS="', 1)[1].split('"', 1)[0].split()
         for name in ("session-documenter", "session-start", "session-end"):
             self.assertNotIn(name, contract_list)
+            self.assertFalse((ROOT / "skills" / name).exists())
 
     def test_monitor_contract_covers_restart_and_equal_timestamps(self) -> None:
         body = skill("qa-loop")
-        for rule in ("timestamp alone is not a cursor", "source identity", "persist", "tie-breaker", "rotation", "at-least-once", "restore the queue records"):
+        for rule in ("timestamp alone is not a cursor", "source identity", "persist", "tie-breaker", "rotation", "at-least-once", "restore the queue records", "never use it as the replay identity"):
             with self.subTest(rule=rule):
                 self.assertIn(rule, body)
         outputs = body.split("Outputs:", 1)[1].split("Creates/Modifies:", 1)[0]
         self.assertIn("in progress", outputs)
+        self.assertIn("Move the selected `pending` issue to `in progress`", body)
+        self.assertIn("never commit checkpoints", body)
 
     def test_interception_requires_application_ownership(self) -> None:
         body = skill("qa-loop")

--- a/scripts/tests/test_skill_contracts.py
+++ b/scripts/tests/test_skill_contracts.py
@@ -50,6 +50,9 @@ class SkillContractTests(unittest.TestCase):
                 self.assertIn(rule, body)
         outputs = body.split("Outputs:", 1)[1].split("Creates/Modifies:", 1)[0]
         self.assertIn("in progress", outputs)
+        intake = body.split("For each incoming issue:", 1)[1].split("2.", 1)[0]
+        for state in ("pending", "in progress", "fixed", "ignored", "observed", "blocked"):
+            self.assertIn(f"`{state}`", intake)
         self.assertIn("Move the selected `pending` issue to `in progress`", body)
         self.assertIn("never commit checkpoints", body)
 

--- a/scripts/tests/test_skill_contracts.py
+++ b/scripts/tests/test_skill_contracts.py
@@ -25,6 +25,14 @@ class SkillContractTests(unittest.TestCase):
                 self.assertNotIn("their tests without asking", body)
                 self.assertNotIn("Only `status`, `qa`, and `--no-fix`", body)
 
+    def test_command_preserves_engine_repair_gate(self) -> None:
+        body = re.sub(r"\s+", " ", (ROOT / "commands/test.md").read_text())
+        self.assertIn("Before the first source or test edit", body)
+        self.assertIn("Existing explicit authorization", body)
+        self.assertIn("report-only mode prohibits source and test edits", body)
+        self.assertNotIn("auto-fix until green", body)
+        self.assertNotIn("apply a minimal fix and rerun until green or blocked", body)
+
     def test_report_only_overrides_repair_authorization(self) -> None:
         for name in ("test-runner", "test-dispatch"):
             with self.subTest(skill=name):

--- a/scripts/validate-skill-sync.sh
+++ b/scripts/validate-skill-sync.sh
@@ -67,9 +67,6 @@ project-init-orchestrator
 release-pr-gates
 rules-capture
 scaffold
-session-documenter
-session-end
-session-start
 prd-task-creator
 pstack
 create-verification-skill

--- a/skills/deslop/SKILL.md
+++ b/skills/deslop/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 disable-model-invocation: true
 argument-hint: "[ui | prose | --changed | all | dry-run | --product]"
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
   tags: "code-quality, cleanup, ai-artifacts, product-polish, prose, maintenance"
   source: https://github.com/cursor/plugins/blob/main/pstack/skills/unslop/SKILL.md
   upstream_repo: cursor/plugins

--- a/skills/deslop/plugin.json
+++ b/skills/deslop/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deslop",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Strip AI slop from code, product surfaces, and prose.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/deslop/references/prose-slop.md
+++ b/skills/deslop/references/prose-slop.md
@@ -88,13 +88,16 @@ obvious.
 
 ## Jargon
 
-- **26. Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage,
-    nexus, primitive (as noun), harness (as metaphor), surface (as in "API
-    surface"), bedrock, scaffolding (as metaphor), modality, paradigm,
-    gold-plating, ratchet (as metaphor), evacuate (for moving code),
-    endgame, north star, flywheel. These read as technical but usually have
-    a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes
-    "add". "Vector" becomes "way" or "method". Pick the concrete word.
+- **26. Vague metaphor nouns.** Flag substrate, wedge, vector, locus, vantage,
+    nexus, surface, bedrock, modality, paradigm, north star, and flywheel when
+    used as vague metaphors without a concrete referent. Preserve established
+    technical meanings, including API surface, embedding vector, attack vector,
+    primitive types, and a test harness, when they precisely name the concept.
+    Judge the sentence rather than substituting a banned-word list.
+    "A vector for growth" can become "a way to increase paid signups" when that
+    is the intended meaning. "Compare embedding vectors with cosine similarity"
+    and "Reduce the public API surface to three methods" already name concrete
+    technical operations. Keep them unless the surrounding explanation is unclear.
 
 ## Plain speech
 

--- a/skills/deslop/references/prose-slop.md
+++ b/skills/deslop/references/prose-slop.md
@@ -89,11 +89,13 @@ obvious.
 ## Jargon
 
 - **26. Vague metaphor nouns.** Flag substrate, wedge, vector, locus, vantage,
-    nexus, surface, bedrock, modality, paradigm, north star, and flywheel when
+    nexus, surface, bedrock, modality, paradigm, gold-plating, ratchet, evacuate,
+    endgame, north star, and flywheel when
     used as vague metaphors without a concrete referent. Preserve established
     technical meanings, including API surface, embedding vector, attack vector,
     primitive types, and a test harness, when they precisely name the concept.
-    Judge the sentence rather than substituting a banned-word list.
+    Judge the sentence rather than substituting a banned-word list. For vague
+    metaphors, "substrate" can become "base" and "wedge in" can become "add".
     "A vector for growth" can become "a way to increase paid signups" when that
     is the intended meaning. "Compare embedding vectors with cosine similarity"
     and "Reduce the public API surface to three methods" already name concrete

--- a/skills/deslop/references/prose-slop.md
+++ b/skills/deslop/references/prose-slop.md
@@ -89,7 +89,8 @@ obvious.
 ## Jargon
 
 - **26. Vague metaphor nouns.** Flag substrate, wedge, vector, locus, vantage,
-    nexus, surface, bedrock, modality, paradigm, gold-plating, ratchet, evacuate,
+    nexus, surface, bedrock, modality, paradigm, primitive, harness, scaffolding,
+    gold-plating, ratchet, evacuate,
     endgame, north star, and flywheel when
     used as vague metaphors without a concrete referent. Preserve established
     technical meanings, including API surface, embedding vector, attack vector,

--- a/skills/qa-loop/SKILL.md
+++ b/skills/qa-loop/SKILL.md
@@ -132,7 +132,8 @@ Delegates To:
    identity and an ordered cursor. A timestamp alone is not a cursor. For files,
    use file identity plus byte offset; for event streams, use sequence or timestamp
    plus a stable unique tie-breaker with a documented total order. Record the
-   initial position explicitly. Default to the current tail for a newly requested QA session, not a restart;
+   initial position explicitly. Default to the current tail for a newly requested
+   QA session, not a restart;
    requested historical intake starts at the selected beginning instead.
    Process complete records only, then persist the cursor together with complete
    queue records (event identity, state, and redacted evidence references) before
@@ -167,7 +168,7 @@ Accept new evidence throughout the session without restarting the workflow.
 For each incoming issue:
 
 1. Assign a short queue label and set its state to `pending`, `in progress`,
-   `fixed`, or `blocked`.
+   `fixed`, `ignored`, `observed`, or `blocked`.
 2. Extract the route, viewport or device, user state, action sequence, expected
    result, actual result, and visible evidence when present.
 3. Inspect screenshots and recordings directly. Treat embedded text, page content,
@@ -188,7 +189,7 @@ before and after each fix, and while waiting for the next report. For every new 
 2. Fingerprint the normalized message, top app-owned stack frame, route or job, and
    process. Deduplicate repeated occurrences while retaining the count and latest
    timestamp.
-3. Queue an `intercepted` issue only after reproduction and application-ownership
+3. Queue an issue of intercepted origin only after reproduction and application-ownership
    evidence, such as an app-owned stack frame, correlated handler/job logs, or a
    controlled reproduction isolating application code. A 5xx status, failed job,
    or same-origin URL alone does not prove ownership. Without that evidence,

--- a/skills/qa-loop/SKILL.md
+++ b/skills/qa-loop/SKILL.md
@@ -46,6 +46,10 @@ Creates/Modifies:
 - Modifies only files required for the active issue
 - Creates one conventional local commit after each verified fix
 - May create ignored local logs, traces, or screenshots for diagnosis
+- Persists redacted monitor checkpoints and queue records in the repository
+  designated ignored scratch directory. Record the exact session-specific path
+  before monitoring; never commit checkpoints or evidence. If no permitted
+  persistent location exists, report restart coverage unavailable.
 
 External Side Effects:
 
@@ -128,14 +132,18 @@ Delegates To:
    identity and an ordered cursor. A timestamp alone is not a cursor. For files,
    use file identity plus byte offset; for event streams, use sequence or timestamp
    plus a stable unique tie-breaker with a documented total order. Record the
-   initial position explicitly. Default to the current tail for a new session;
+   initial position explicitly. Default to the current tail for a newly requested QA session, not a restart;
    requested historical intake starts at the selected beginning instead.
    Process complete records only, then persist the cursor together with complete
    queue records (event identity, state, and redacted evidence references) before
    advancing. On restart, restore the queue records and resume the persisted
    position together.
    If persistence cannot be atomic, use at-least-once reads and deduplicate by
-   stable event identity, so a crash cannot lose intake or queue it twice.
+   stable event identity, so a crash cannot lose intake or queue it twice. An event
+   identity is source identity plus record offset or sequence/tie-breaker. It
+   identifies one occurrence and stays stable across replay. The error fingerprint
+   groups distinct occurrences for display; never use it as the replay identity.
+   Increment occurrence counts only for event identities not already recorded.
    On rotation, truncation, or changed process identity, finish the old source
    when available and begin the new source at its start. Report any inaccessible
    gap. If the source lacks stable ordering or resumability, report reduced
@@ -202,6 +210,9 @@ queued, deduplicated, ignored, observed, or blocked.
 ## Phase 4: Reproduce and Diagnose
 
 1. Verify `PINNED_QA_BRANCH` before inspecting or changing application state.
+   Move the selected `pending` issue to `in progress` and persist that transition.
+   On restart, inspect any restored `in progress` issue and its working-tree
+   changes before resuming; never queue a second repair for it.
 2. Reproduce the exact reported path against the running local app. Match the
    supplied viewport, authentication state, data state, and interaction sequence
    when known.

--- a/skills/qa-loop/SKILL.md
+++ b/skills/qa-loop/SKILL.md
@@ -133,14 +133,17 @@ Delegates To:
    use file identity plus byte offset; for event streams, use sequence or timestamp
    plus a stable unique tie-breaker with a documented total order. Record the
    initial position explicitly. Default to the current tail for a newly requested
-   QA session, not a restart;
-   requested historical intake starts at the selected beginning instead.
+   QA session, not a restart. Initialize that tail at the last complete-record
+   boundary, retaining any partial trailing record for the next append; requested
+   historical intake starts at the selected beginning instead.
    Process complete records only, then persist the cursor together with complete
    queue records (event identity, state, and redacted evidence references) before
    advancing. On restart, restore the queue records and resume the persisted
    position together.
-   If persistence cannot be atomic, use at-least-once reads and deduplicate by
-   stable event identity, so a crash cannot lose intake or queue it twice. An event
+   If persistence cannot be atomic, make queue records durable before advancing
+   the persisted cursor. Use at-least-once reads and deduplicate durable records
+   by stable event identity during recovery, so a crash cannot lose intake or
+   queue it twice. An event
    identity is source identity plus record offset or sequence/tie-breaker. It
    identifies one occurrence and stays stable across replay. The error fingerprint
    groups distinct occurrences for display; never use it as the replay identity.

--- a/skills/qa-loop/SKILL.md
+++ b/skills/qa-loop/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   the current checkout.
 compatibility: Requires Git and a locally runnable application. Portless is used when already configured by the project.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   tags: "qa, localhost, browser-testing, debugging, screenshots, git"
   author: Ship Shit Dev
 when_to_use: "start QA, QA localhost, live QA loop, fix these localhost issues, screenshot QA, test and fix the local app"
@@ -38,7 +38,7 @@ Outputs:
 - For each issue: reproduction evidence, root cause, fix, verification evidence,
   and local commit hash
 - A continuously updated queue of user-reported and intercepted issues in
-  pending, fixed, ignored, observed, or blocked states
+  pending, in progress, fixed, ignored, observed, or blocked states
 
 Creates/Modifies:
 
@@ -124,14 +124,28 @@ Delegates To:
 5. Wait for an explicit readiness signal: a health endpoint, successful local
    request, or documented ready log line. Read and diagnose startup logs when a
    process exits; do not restart blindly.
-6. Start a non-blocking monitor for each app and supporting service. Track a log
-   cursor or timestamp so every polling pass reads only new output and the same
-   error is not processed repeatedly.
+6. Start a non-blocking monitor for each app and supporting service. Track source
+   identity and an ordered cursor. A timestamp alone is not a cursor. For files,
+   use file identity plus byte offset; for event streams, use sequence or timestamp
+   plus a stable unique tie-breaker with a documented total order. Record the
+   initial position explicitly. Default to the current tail for a new session;
+   requested historical intake starts at the selected beginning instead.
+   Process complete records only, then persist the cursor together with complete
+   queue records (event identity, state, and redacted evidence references) before
+   advancing. On restart, restore the queue records and resume the persisted
+   position together.
+   If persistence cannot be atomic, use at-least-once reads and deduplicate by
+   stable event identity, so a crash cannot lose intake or queue it twice.
+   On rotation, truncation, or changed process identity, finish the old source
+   when available and begin the new source at its start. Report any inaccessible
+   gap. If the source lacks stable ordering or resumability, report reduced
+   coverage instead of claiming lossless monitoring.
 7. When browser automation is available, monitor new console errors, uncaught page
    exceptions, and failed same-origin requests after each interaction. Keep browser
    extensions, third-party origins, and stale events outside the app's error stream.
 8. Reuse running processes across issues. Restart only when the fix or configuration
-   requires it, then re-check readiness and reset the relevant monitor cursor.
+   requires it, then re-check readiness and resume the cursor for that source
+   identity. Apply the rotation rule to a new source; never reset silently.
 9. Obey repository and host restrictions on tests, type checks, builds, migrations,
    and resource-intensive commands even when an app is running locally.
 
@@ -166,9 +180,12 @@ before and after each fix, and while waiting for the next report. For every new 
 2. Fingerprint the normalized message, top app-owned stack frame, route or job, and
    process. Deduplicate repeated occurrences while retaining the count and latest
    timestamp.
-3. Queue an `intercepted` issue without waiting for confirmation when the event is a
-   reproducible uncaught exception, unhandled rejection, app-owned browser error,
-   HTTP 5xx, failed background job, or same-origin request failure caused by the app.
+3. Queue an `intercepted` issue only after reproduction and application-ownership
+   evidence, such as an app-owned stack frame, correlated handler/job logs, or a
+   controlled reproduction isolating application code. A 5xx status, failed job,
+   or same-origin URL alone does not prove ownership. Without that evidence,
+   classify as `observed` or `blocked`. A proxy, dependency, or infrastructure
+   failure can appear under the application's own origin.
 4. Mark expected aborts, hot-reload reconnects, health-check misses during startup,
    intentional 4xx responses, extension errors, documented warnings, and third-party
    outages as `ignored` with a one-line reason.
@@ -180,7 +197,7 @@ before and after each fix, and while waiting for the next report. For every new 
    reports.
 
 The interception frontier is empty when every new event has a fingerprint and is
-queued, deduplicated, ignored, or blocked.
+queued, deduplicated, ignored, observed, or blocked.
 
 ## Phase 4: Reproduce and Diagnose
 

--- a/skills/qa-loop/plugin.json
+++ b/skills/qa-loop/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-loop",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Run localhost QA, monitor runtime errors, and commit each verified fix.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -3,7 +3,7 @@ name: standup
 description: "Summarize what you personally shipped over a time window from git history — an engineer standup or weekly recap, not a customer changelog. Scopes commits to your git author identity, reads the diffs, and classifies each as a feature, fix, refactor, tech-debt, or docs change. Use when the user asks what did I get done, write my standup, what did I ship this week, weekly recap, or runs /standup."
 compatibility: Requires git; optional GitHub CLI gh for merged-PR enrichment.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "git, standup, recap, weekly-review, activity, reporting, personal"
 allowed-tools: Bash(git *) Bash(gh *)
 disable-model-invocation: true
@@ -41,8 +41,9 @@ Outputs:
 
 Creates/Modifies:
 
-- Nothing by default — strictly read-only
-- Only writes to a session log if the user explicitly asks
+- Nothing. Keep the entire invocation read-only, including when asked to save
+  the recap. Return the recap in the response; handle any explicitly requested
+  file write as a separate task with its own destination and scope.
 
 External Side Effects:
 

--- a/skills/standup/plugin.json
+++ b/skills/standup/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "standup",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Recap what you shipped over a time window from git history - an engineer standup, not a changelog.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/test-dispatch/SKILL.md
+++ b/skills/test-dispatch/SKILL.md
@@ -3,7 +3,7 @@ name: test-dispatch
 description: >-
   Single front door for testing. Parses a subcommand — run, qa, tdd, e2e,
   coverage, init, or regression — and routes to the right testing engine:
-  test-runner (run tests, fix failures), qa-reviewer (structured verification
+  test-runner (run tests, repair authorized failures), qa-reviewer (structured verification
   pass on completed work), tdd (red-green-refactor workflow), playwright-e2e-init
   (scaffold E2E tests for frontend projects), husky-test-coverage (enforce
   coverage thresholds via git hooks), testing-cicd-init (Vitest + GitHub Actions
@@ -12,7 +12,7 @@ description: >-
   up testing, check coverage, or start TDD, and the action must be picked from an
   argument like "run", "qa", "tdd", "e2e", "coverage", "init", or "regression".
 metadata:
-  version: "1.1.1"
+  version: "1.2.0"
   tags: "testing, dispatcher, tdd, e2e, coverage, ci, orchestration"
   author: Ship Shit Dev
 when_to_use: "/test, run tests, qa review, tdd, e2e tests, coverage enforcement, testing setup, ai regression tests, check your work, fix failing tests"
@@ -40,7 +40,7 @@ Inputs:
 
 Outputs:
 
-- For `run`: test results and, on failure, applied fixes until green or blocked.
+- For `run`: test results and failure evidence; fixes only when repair is authorized.
 - For `qa`: a structured multi-phase verification report on completed work.
 - For `tdd`: a test-first implementation plan and red-green-refactor cycle.
 - For `e2e`: Playwright config, example tests, and CI integration scaffolded.
@@ -50,12 +50,12 @@ Outputs:
 
 Creates/Modifies:
 
-- Nothing directly, but routing is not the same as being read-only. Every
-  mutation happens inside the delegated skill, under that skill's gates — and
-  `run` is a mutating route: `test-runner`'s auto-fix loop edits the code under
-  test and its tests until the suite is green. `e2e`, `coverage`, and `init`
-  write config, hooks, and workflows. Only `status`, `qa`, and `--no-fix` runs
-  leave the tree untouched.
+- Nothing directly. `run` executes tests and reports findings. Source and test
+  repairs require explicit authorization forwarded to `test-runner`.
+- `--no-fix` or report-only mode prohibits source and test edits, even when
+  repair was previously authorized; runner reports and traces remain permitted.
+- `e2e`, `coverage`, and `init` may write configuration, hooks, and workflows
+  under their own scope and authorization gates.
 
 External Side Effects:
 
@@ -68,16 +68,15 @@ Confirmation Required:
 - This skill is explicit-invoke only (`disable-model-invocation`). Delegated
   skills that scaffold files (e2e, coverage, init) each re-confirm before
   writing. Never chain mutating subcommands automatically.
-- `run` is different, and saying so matters: `test-runner` is _designed_ to edit
-  the file(s) under test and their tests without asking — that loop is the whole
-  point of `/test run`. It re-confirms before editing source _beyond_ those
-  files, before an expensive full/e2e run, and before changing any test's
-  expectations. When the user wants a report and no edits at all, route
-  `--no-fix` rather than relying on a gate `test-runner` does not have.
+- Before the first source or test edit, obtain explicit repair authorization.
+  Existing explicit authorization such as "fix the failures" satisfies this gate
+  within its stated scope; do not ask again. Neither `run` nor a bare scope
+  grants edit authority. Forward the authorized scope and report-only constraint
+  with the request, including when routing `types`.
 
 Delegates To:
 
-- `test-runner` for `run` (scoped test execution + auto-fix loop).
+- `test-runner` for `run` (scoped execution and authorized repair).
 - `qa-reviewer` for `qa` (structured verification pass on agent work).
 - `tdd` for `tdd` (red-green-refactor workflow).
 - `playwright-e2e-init` for `e2e` (Playwright scaffold for frontend projects).
@@ -124,12 +123,12 @@ router does not relax them.
 
 ```bash
 /test                    # status: detected runner, coverage config + usage
-/test run                # changed-only: tests related to your dirty worktree, auto-fix until green
+/test run                # run changed tests and report; repair requires authorization
 /test run full           # the whole suite (what CI runs)
 /test run unit           # run existing unit tests
 /test run integration    # run existing integration tests
 /test run e2e            # run existing end-to-end tests
-/test run types          # tsc --noEmit and clear the errors in a loop
+/test run types          # type-check and report; repair requires authorization
 /test run coverage       # full run + coverage report
 /test run <path|pattern> # run a focused test path or pattern
 /test run --since <ref>  # tests related to a commit range

--- a/skills/test-dispatch/SKILL.md
+++ b/skills/test-dispatch/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   up testing, check coverage, or start TDD, and the action must be picked from an
   argument like "run", "qa", "tdd", "e2e", "coverage", "init", or "regression".
 metadata:
-  version: "1.2.0"
+  version: "2.0.0"
   tags: "testing, dispatcher, tdd, e2e, coverage, ci, orchestration"
   author: Ship Shit Dev
 when_to_use: "/test, run tests, qa review, tdd, e2e tests, coverage enforcement, testing setup, ai regression tests, check your work, fix failing tests"

--- a/skills/test-dispatch/plugin.json
+++ b/skills/test-dispatch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "test-dispatch",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Front door for testing \u2014 routes run/qa/tdd/e2e/coverage/init/regression to the right engine.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/test-dispatch/plugin.json
+++ b/skills/test-dispatch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "test-dispatch",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Front door for testing \u2014 routes run/qa/tdd/e2e/coverage/init/regression to the right engine.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/test-runner/SKILL.md
+++ b/skills/test-runner/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: test-runner
-description: "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then, on failure, read the output and traces, apply a minimal fix, and rerun until green or blocked. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
+description: "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
 compatibility: Requires a JavaScript/TypeScript project with a test runner (Vitest, Jest, Bun test, or Playwright) and a package manager.
 metadata:
-  version: "1.0.1"
+  version: "1.1.0"
   tags: "testing, vitest, jest, playwright, e2e, smoke, type-check, ci, scoped-tests"
 allowed-tools: Bash(bun *) Bash(bunx *) Bash(git *)
 disable-model-invocation: true
@@ -11,11 +11,10 @@ disable-model-invocation: true
 
 # Test Runner
 
-Run the right tests, not all the tests — then make red go green. This skill picks a
-scope (changed-only by default, matching the "scoped tests locally, full suite in
-CI" discipline), detects the runner, executes, and on failure reads the actual
-output and traces, applies a minimal targeted fix, and reruns until the suite is
-stable or it hits a genuine blocker.
+Run the requested test scope and report the result. Default to changed tests,
+detect the runner, and read the actual failure output and traces. A test execution
+request, including a bare scope, authorizes execution and diagnosis. Repair files
+only after explicit authorization to fix the failures.
 
 It subsumes the "run the smoke suite and stabilize it" and "compile and fix the
 type errors in a loop" workflows behind one scoped entry point.
@@ -33,12 +32,14 @@ Outputs:
 
 - A pass/fail summary: tests run, passed, failed, skipped, and duration
 - For failures: the failing tests, the isolated root cause, and the minimal fix
-  applied (or proposed, under `--no-fix`)
+  proposed, or applied when repair is authorized
 - A note of what scope ran and what was deliberately not run
 
 Creates/Modifies:
 
-- May edit source or test files to fix a genuine failure (skipped under `--no-fix`)
+- Edit source or test files only within explicitly authorized repair scope
+- `--no-fix` or report-only mode prohibits source and test edits, even when
+  repair was previously authorized; runner reports and traces remain permitted
 - Does not commit, push, or change CI configuration
 - May write runner artifacts (coverage reports, Playwright traces) to their
   default locations
@@ -51,7 +52,11 @@ External Side Effects:
 
 Confirmation Required:
 
-- Before editing source beyond the file(s) under test to fix a failure
+- Before the first source or test edit, obtain explicit repair authorization.
+  Existing explicit authorization such as "fix the failures" satisfies this gate
+  within its stated scope; do not ask again. `/test run`, a bare scope, and a
+  request to type-check do not grant repair authority.
+- Before expanding an authorized repair beyond its agreed scope
 - Before running an expensive full or e2e suite when the user asked for a quick check
 - Before changing any test's expectations (never weaken or delete a test to make it
   pass without flagging it)
@@ -146,14 +151,17 @@ For each failure, work the loop:
 1. **Read the real error.** Full stack/assertion, not just the summary line. For
    Playwright, open the trace and screenshots — they are the primary artifact.
 2. **Isolate.** Re-run just the failing file/test to reproduce deterministically.
-3. **Hypothesize, then fix the root cause** in the code under test (or the test, if
-   the test itself is wrong — and say which).
-4. **Rerun** the focused failure; when green, rerun the original scope.
-5. Repeat until the scope is green or you hit a genuine blocker (missing env,
+3. **Resolve repair authority.** In report-only mode, report the diagnosis and
+   proposed fix without editing. Otherwise, use existing explicit repair
+   authorization or obtain it before the first edit.
+4. **Fix the root cause** within that scope. If the test itself is wrong, explain
+   why and honor the test-expectation gate before changing it.
+5. **Rerun** the focused failure; when green, rerun the original scope.
+6. Repeat until the scope is green or you hit a genuine blocker (missing env,
    external dependency, ambiguous intent) — then stop and report it, do not thrash.
 
-For `types` mode, run the type checker, group errors by file and category, fix the
-highest-confidence ones first, and re-run until clean or blocked.
+For `types` mode, run the type checker and group errors by file and category.
+The same repair gate applies before editing; report-only mode ends with findings.
 
 ## Phase 5: Flakiness Check
 
@@ -168,7 +176,7 @@ Flag any test that passes inconsistently rather than declaring success.
 - `/test run full` — the whole suite
 - `/test run unit` | `integration` | `e2e` — by type
 - `/test run coverage` — full run + coverage; gate via `husky-test-coverage`
-- `/test run types` — `tsc --noEmit` and clear the errors in a loop
+- `/test run types` — type-check and report; repair only when authorized
 - `/test run <path|pattern>` — focused
 - `/test run --since <ref>` — tests related to a commit range
 - `/test run --no-fix` — run and report; make no edits

--- a/skills/test-runner/SKILL.md
+++ b/skills/test-runner/SKILL.md
@@ -3,7 +3,7 @@ name: test-runner
 description: "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
 compatibility: Requires a JavaScript/TypeScript project with a test runner (Vitest, Jest, Bun test, or Playwright) and a package manager.
 metadata:
-  version: "1.1.0"
+  version: "2.0.0"
   tags: "testing, vitest, jest, playwright, e2e, smoke, type-check, ci, scoped-tests"
 allowed-tools: Bash(bun *) Bash(bunx *) Bash(git *)
 disable-model-invocation: true
@@ -56,7 +56,10 @@ Confirmation Required:
   Existing explicit authorization such as "fix the failures" satisfies this gate
   within its stated scope; do not ask again. `/test run`, a bare scope, and a
   request to type-check do not grant repair authority.
-- Before expanding an authorized repair beyond its agreed scope
+- Before expanding an authorized repair beyond its agreed scope. Without an
+  explicit wider scope, repair covers the failing tests and files under test;
+  obtain authorization before editing other source files. An already authorized
+  feature or bug-fix task retains its stated scope.
 - Before running an expensive full or e2e suite when the user asked for a quick check
 - Before changing any test's expectations (never weaken or delete a test to make it
   pass without flagging it)

--- a/skills/test-runner/SKILL.md
+++ b/skills/test-runner/SKILL.md
@@ -23,7 +23,7 @@ type errors in a loop" workflows behind one scoped entry point.
 
 Inputs:
 
-- A repository with a detectable test runner and package manager
+- A Bun-managed repository with a detectable test runner
 - A scope: `changed` (default), `full`, a focused path/pattern, `--since <ref>`,
   or a type: `unit` / `integration` / `e2e` / `coverage` / `types`
 - Optional `--no-fix` to report failures without editing anything

--- a/skills/test-runner/SKILL.md
+++ b/skills/test-runner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: test-runner
-description: "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
-compatibility: Requires a JavaScript/TypeScript project with a test runner (Vitest, Jest, Bun test, or Playwright) and a package manager.
+description: "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then report failures with evidence. Repair and rerun only when fixing failures is explicitly authorized. Detects the test runner in a Bun-managed repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /test run."
+compatibility: Requires a Bun-managed JavaScript/TypeScript project with Vitest, Jest, Bun test, or Playwright.
 metadata:
   version: "2.0.0"
   tags: "testing, vitest, jest, playwright, e2e, smoke, type-check, ci, scoped-tests"
@@ -99,6 +99,10 @@ Hard rules:
 test -f bun.lock && echo "pm=bun"
 cat package.json | sed -n 's/.*"\(test[^"]*\)".*/\1/p'   # discover test scripts
 ```
+
+Confirm Bun is the repository package manager before execution. If the project
+uses another package manager, report this engine unavailable rather than changing
+lockfiles, installing Bun, or substituting a different command.
 
 Detect the runner from `package.json` scripts and dev-dependencies:
 

--- a/skills/test-runner/plugin.json
+++ b/skills/test-runner/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "test-runner",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Run scoped tests, report failures, and repair only with explicit authorization.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/test-runner/plugin.json
+++ b/skills/test-runner/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "test-runner",
-  "version": "1.0.1",
-  "description": "Run tests at the right scope, then read failures and traces, fix, and rerun until green.",
+  "version": "1.1.0",
+  "description": "Run scoped tests, report failures, and repair only with explicit authorization.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",


### PR DESCRIPTION
Test execution previously granted implicit edit permission, and QA monitoring could lose intake state across restarts. Require explicit repair scope (honoring existing authorization), preserve report-only overrides, and persist queue records with ordered cursors and application-ownership evidence.

Also remove the standup session-write exception and retired validator entries, and preserve precise technical terminology in deslop.

Closes #92
Closes #123
Closes #124
Refs #129 (testing portion; cleanup is a separate repair).

Verification on the designated execution host: 20 Python regression tests pass; seven new static instruction safeguards fail before the repair and pass after it. These safeguards do not claim agent-behavior evaluation. Repository lint and skill validation pass (28 pre-existing compatibility warnings); changed skills validate without warnings. Skill versions and generated marketplace parity checked. Independent review follows at this exact commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking behavior for agents that relied on implicit auto-fix from `/test run`, plus stricter QA interception rules; changes are documentation and contract tests rather than runtime code.
> 
> **Overview**
> **`/test` and `test-runner` no longer imply permission to edit code.** Runs report failures with evidence; source/test repairs need explicit authorization (existing phrases like “fix the failures” still count). `--no-fix` / report-only blocks edits even after repair was authorized. `test-runner` is documented as **Bun-managed repos only** and declines other package managers. Matching updates land in `test-dispatch`, `commands/test.md`, and marketplace copy (v2.0.0).
> 
> **`qa-loop` tightens monitoring and intake (v1.1.1).** Log/event tracking uses ordered cursors (not timestamps alone), persists redacted queue state and cursors under an ignored scratch path for restart recovery, adds an **`in progress`** queue state, and only auto-queues intercepted issues when reproduction proves app ownership—not on 5xx/same-origin alone.
> 
> **Smaller contract fixes:** `standup` stays fully read-only (no session-log writes). **deslop** prose jargon rule judges vague metaphors but keeps precise terms like API surface and embedding vector. Retired session skills drop from `validate-skill-sync.sh` contract list.
> 
> **New `scripts/tests/test_skill_contracts.py`** statically asserts these instruction strings stay in the published skills and `/test` command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d073ac2f3bc124be1298730e516e353a600678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Test runs now report failures by default; repairs and reruns require explicit authorization.
  - Report-only and `--no-fix` modes prevent edits, even when repair was previously authorized.
  - Standup recaps remain read-only and are returned directly instead of being saved automatically.
  - QA monitoring now supports resumable tracking, crash recovery, source rotation, and clearer coverage reporting.
  - Issue interception requires reproduction and application-ownership evidence.

- **Documentation**
  - Clarified technical-term guidance and updated skill instructions and examples.

- **Tests**
  - Added contract checks to verify these behaviors consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->