### PR TITLE
feat(weekly-review): coordinate recurring engineering maintenance

### DIFF
--- a/.agents/memory/architecture.md
+++ b/.agents/memory/architecture.md
@@ -9,19 +9,19 @@ last_verified: 2026-07-13
 |---|---|---|
 | `.agents/` | Repository memory, standards, and maintenance skills | Tracked |
 | `.claude/` | Claude loader adapters for shared maintenance content | Tracked |
-| `.claude-plugin/` | Generated Claude marketplace catalog | 199 generated plugins |
+| `.claude-plugin/` | Generated Claude marketplace catalog | 200 generated plugins |
 | `.codex/` | Codex loader adapters for shared maintenance content | Tracked |
 | `.github/` | Issue templates and GitHub Actions workflows | Tracked |
 | `.husky/` | Git hook configuration | Tracked |
 | `.tmp/` | Tracked repository content | Tracked |
 | `assets/` | Static repository assets | Tracked |
 | `bundles/` | Generated marketplace bundle snapshots | 13 generated bundles |
-| `commands/` | Claude Code/plugin command adapters | 29 command adapters |
+| `commands/` | Claude Code/plugin command adapters | 30 command adapters |
 | `docs/` | Human-facing orientation pages for flagship skills | Tracked |
 | `prompts/` | Shared prompt resources | Tracked |
 | `resources/` | Authoring references and supporting documentation | Tracked |
 | `scripts/` | Validation, generation, migration, and audit tooling | Tracked |
-| `skills/` | Canonical public Agent Skills sources | 186 canonical skills |
+| `skills/` | Canonical public Agent Skills sources | 187 canonical skills |
 <!-- catalog-layout:end -->
 
 ## Data Flow

--- a/.agents/memory/memory.md
+++ b/.agents/memory/memory.md
@@ -7,7 +7,7 @@ last_verified: 2026-08-14
 <!-- catalog-summary:start -->
 Public skills library at `shipshitdev/skills`. Installable via `npx skills add shipshitdev/skills --skill <name>`. Works with Claude Code, Codex, Cursor, OpenClaw, and Gemini.
 
-Generated catalog: **186 skills · 29 commands · 13 bundles · 199 plugins**.
+Generated catalog: **187 skills · 30 commands · 13 bundles · 200 plugins**.
 <!-- catalog-summary:end -->
 
 Published through committed marketplace bundles in `bundles/` and the generated `.claude-plugin/marketplace.json` catalog. The old generated `plugins/` package tree is retired.
@@ -26,10 +26,10 @@ Published through committed marketplace bundles in `bundles/` and the generated 
 <!-- catalog-counts:start -->
 | Asset | Count | Canonical source |
 |---|---:|---|
-| Skills | 186 | `skills/*/SKILL.md` |
-| Commands | 29 | `commands/*.md` |
+| Skills | 187 | `skills/*/SKILL.md` |
+| Commands | 30 | `commands/*.md` |
 | Bundles | 13 | `scripts/plugin-categories.json` |
-| Plugins | 199 | skills + bundles |
+| Plugins | 200 | skills + bundles |
 <!-- catalog-counts:end -->
 
 ## Architecture Decisions
@@ -108,6 +108,15 @@ Adapted selected patterns from [mattpocock/skills](https://github.com/mattpocock
 - New adapted primitives: `grilling`, `domain-modeling`, `wait-what`, `wizard`, `prototype`, `codebase-design`.
 - New user-invoked router: `ask-dev-loop`. `interview` / `shape` invoke `grilling`; they hint at other user-invoked skills rather than firing them.
 - `tdd` provenance completed; `code-review` gained a Spec axis; flagship human docs live in `docs/skills/`.
+
+### Weekly review composition (2026-09-05)
+
+`weekly-review` coordinates board evidence, issue-to-code checks, a frozen
+all-author retrospective, operational evidence, and scoped deslop. Report-only
+is the default. Existing scoped repair authorization carries to engines; board
+writes and deployment actions keep their own boundaries. Code coverage controls
+the next review checkpoint, with unresolved work retained separately. Shipshit
+`deslop` and upstream `pstack:deslop` remain separate implementations.
 
 ## Known Issues
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "Ship Shit Dev"
   },
-  "description": "186 AI agent skills for development workflows",
+  "description": "187 AI agent skills for development workflows",
   "plugins": [
     {
       "name": "shipshitdev-testing",
@@ -1168,6 +1168,12 @@
       "source": "./skills/wait-what",
       "version": "1.0.0",
       "description": "Re-pitch the last message in plain English using the project's CONTEXT.md vocabulary."
+    },
+    {
+      "name": "weekly-review",
+      "source": "./skills/weekly-review",
+      "version": "1.0.0",
+      "description": "Coordinates a weekly engineering review of board accuracy, recent code changes, operational health, and scoped cleanup. Use for a recurring repository health review or a review of the last several days."
     },
     {
       "name": "why",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Skills Repo — Agent Instructions
 
 <!-- catalog-summary:start -->
-This is the shipshitdev/skills repo: 186 AI agent skills for Claude Code, Codex, and Cursor. The generated catalog also contains 29 command adapters, 13 bundles, and 199 marketplace plugins.
+This is the shipshitdev/skills repo: 187 AI agent skills for Claude Code, Codex, and Cursor. The generated catalog also contains 30 command adapters, 13 bundles, and 200 marketplace plugins.
 <!-- catalog-summary:end -->
 
 ## Repo Structure

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ![Project Type](https://img.shields.io/badge/Project-Skills-blue)
 
 <!-- catalog-summary:start -->
-186 AI agent skills for development workflows. Works with Claude Code, OpenAI Codex, and Cursor.
+187 AI agent skills for development workflows. Works with Claude Code, OpenAI Codex, and Cursor.
 
-Catalog: **186 skills · 29 commands · 13 bundles · 199 plugins**.
+Catalog: **187 skills · 30 commands · 13 bundles · 200 plugins**.
 <!-- catalog-summary:end -->
 
 Skills are **model-agnostic playbooks**: the harness supplies the model, so no skill names a concrete model — orchestrators speak in capability tiers, and each repo's routing block maps tiers to models. Enforced by `scripts/validate-skill-sync.sh`; standards live in `.agents/memory/system/skill-standards.md`.
@@ -19,19 +19,19 @@ Skills are **model-agnostic playbooks**: the harness supplies the model, so no s
 |---|---|---|
 | `.agents/` | Repository memory, standards, and maintenance skills | Tracked |
 | `.claude/` | Claude loader adapters for shared maintenance content | Tracked |
-| `.claude-plugin/` | Generated Claude marketplace catalog | 199 generated plugins |
+| `.claude-plugin/` | Generated Claude marketplace catalog | 200 generated plugins |
 | `.codex/` | Codex loader adapters for shared maintenance content | Tracked |
 | `.github/` | Issue templates and GitHub Actions workflows | Tracked |
 | `.husky/` | Git hook configuration | Tracked |
 | `.tmp/` | Tracked repository content | Tracked |
 | `assets/` | Static repository assets | Tracked |
 | `bundles/` | Generated marketplace bundle snapshots | 13 generated bundles |
-| `commands/` | Claude Code/plugin command adapters | 29 command adapters |
+| `commands/` | Claude Code/plugin command adapters | 30 command adapters |
 | `docs/` | Human-facing orientation pages for flagship skills | Tracked |
 | `prompts/` | Shared prompt resources | Tracked |
 | `resources/` | Authoring references and supporting documentation | Tracked |
 | `scripts/` | Validation, generation, migration, and audit tooling | Tracked |
-| `skills/` | Canonical public Agent Skills sources | 186 canonical skills |
+| `skills/` | Canonical public Agent Skills sources | 187 canonical skills |
 <!-- catalog-layout:end -->
 
 ## What's Included
@@ -237,6 +237,7 @@ or another Agent Skills-compatible harness.
 | suggest | Post inline suggested changes on a PR |
 | test | One testing front door — run, qa, tdd, e2e, coverage, init, regression |
 | wait-what | Re-pitch the last message in plain English |
+| weekly-review | Audit board accuracy, recent changes, operations, and scoped cleanup |
 
 ### Intentional shortcuts, not duplicates
 
@@ -251,8 +252,21 @@ or another Agent Skills-compatible harness.
   `/refactor perf`, and every `/tests <scope>` spelling is now
   `/test run <scope>`.
 
+### Weekly engineering review
+
+Run `/weekly-review 7d` with a repository and board URL for an evidence-backed
+report on issue accuracy, recent changes, operational gaps, and deslop findings.
+Use `since <SHA>` to resume from a completed review checkpoint. Add `--fix` for
+scoped code repairs; board writes and other external actions retain their own
+authorization boundaries. The workflow does not schedule itself.
+
+The coordinator reuses [weekly-review](skills/weekly-review/SKILL.md)'s declared
+engines. Install those companions when they are absent from the active catalog.
+Plain `deslop` is the Shipshit adaptation. `pstack:deslop` is a separate upstream
+plugin skill, not an alias.
+
 <!-- catalog-skills-heading:start -->
-## Skills (186)
+## Skills (187)
 <!-- catalog-skills-heading:end -->
 
 ### Dev Loop (15)

--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ scoped code repairs; board writes and other external actions retain their own
 authorization boundaries. The workflow does not schedule itself.
 
 The coordinator reuses [weekly-review](skills/weekly-review/SKILL.md)'s declared
-engines. Install those companions when they are absent from the active catalog.
+engines. When preparing an installation, select the coordinator and any missing
+companions. During a review, missing companions are reported without installation.
 Plain `deslop` is the Shipshit adaptation. `pstack:deslop` is a separate upstream
 plugin skill, not an alias.
 

--- a/bundles/dev-workflow/README.md
+++ b/bundles/dev-workflow/README.md
@@ -52,6 +52,6 @@ Code review, debugging, refactoring, release, and AI-assisted development workfl
 - `systematic-debugging`
 - `tech-debt`
 - `verification-before-completion`
+- `weekly-review`
 - `wizard`
 - `worktree`
-- `weekly-review`

--- a/bundles/dev-workflow/README.md
+++ b/bundles/dev-workflow/README.md
@@ -54,3 +54,4 @@ Code review, debugging, refactoring, release, and AI-assisted development workfl
 - `verification-before-completion`
 - `wizard`
 - `worktree`
+- `weekly-review`

--- a/bundles/dev-workflow/skills/weekly-review/SKILL.md
+++ b/bundles/dev-workflow/skills/weekly-review/SKILL.md
@@ -134,9 +134,12 @@ rechecking evidence when the branch has advanced. A weekly request does not
 authorize a whole-tree rewrite.
 
 Run the `test-runner` skill for affected verification, preserving host restrictions
-and the authorized repair scope. Use fresh CI and required review gates for
-publication and any separately authorized merge. Keep fixes isolated from
-unrelated work; failed checks remain unresolved findings.
+and the authorized repair scope. Satisfy repository-required local checks and
+review gates before publication. If the allowed verification host is unavailable,
+keep the repair unverified; do not substitute CI for required local checks.
+Follow the repository's policy for any draft PR. Use fresh CI and required review
+for a separately authorized merge. Report completed actions separately from
+planned actions. Failed checks remain unresolved findings.
 
 Re-read affected board evidence after repairs. Apply only separately authorized,
 provider-supported corrections through `board-sync`. Issue closure and Jira
@@ -155,7 +158,9 @@ Deliver one concise report with evidence links:
 - **Repaired:** exact changes, verification, PRs, and remaining delivery gates
 - **Next priorities:** the three highest-value actions, or fewer when justified
 - **Checkpoint:** END only for completely reviewed code scope; retain the previous
-  checkpoint and exact remaining scope when review is partial. Track unresolved
+  checkpoint and exact remaining scope when review is partial. Required cross-package
+  contract and consumer checks are part of that scope; an uninspected required
+  consumer prevents advancing the affected checkpoint. Track unresolved
   findings and incomplete board/operational checks separately for the next run.
 
 An empty commit window still permits board and operational review. State no code

--- a/bundles/dev-workflow/skills/weekly-review/SKILL.md
+++ b/bundles/dev-workflow/skills/weekly-review/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: weekly-review
+description: Coordinates a weekly engineering review of board accuracy, recent code changes, operational health, and scoped cleanup. Use for a recurring repository health review or a review of the last several days.
+compatibility: Requires repository history and access to the selected board; operational checks depend on existing service connections.
+metadata:
+  version: "1.0.0"
+  tags: "review, weekly, maintenance, boards, retrospective"
+  author: Ship Shit Dev
+---
+
+# Weekly Review
+
+Turn a review period into an evidence-backed maintenance report and, when
+requested, verified repairs. Reuse the review and cleanup engines. Keep provider
+procedures and review rubrics in their owning skills.
+
+## Contract
+
+Inputs:
+
+- Repository or monorepo, board URL/provider, and optional package scope
+- A window such as `7d` (default), explicit dates with timezone, or `since <SHA>`
+- Optional previous review checkpoint and explicitly authorized repair scope
+- Report-only by default; `--fix` authorizes code repairs for confirmed findings
+  within the reviewed scope; `--report-only` overrides earlier repair authority
+
+Outputs:
+
+- One report of shipped, broken, drifted, blocked, repaired, and next priorities
+- Evidence and coverage per repository, issue, package, and operational check
+- Reviewed commit endpoints and a proposed next checkpoint, with unfinished work
+
+Creates/Modifies:
+
+- Nothing in report-only mode; return the report and checkpoint in the response
+- In repair mode: scoped source/test edits and verification artifacts; publish
+  repair PRs according to the repository's existing delivery policy
+
+External Side Effects:
+
+- Reads repository, board, CI, deployment, and available monitoring evidence
+- Board edits, issue filing/closure, comments, merges, deployments, installations,
+  and scheduling require their own explicit scope; `--fix` grants none of these
+
+Confirmation Required:
+
+- Only for missing or expanded authority; preserve existing explicit approval
+  for the same target/actions and forward restrictions to every delegate
+- Review requests and findings are not permission to modify production
+
+Delegates To:
+
+- `board-sync` for board reconciliation and approved supported field corrections
+- `full-code-review` for retrospective review using the frozen diff and commit log
+- `code-review` for correctness and implementation-versus-acceptance checks
+- `deslop` for scoped dry-run findings or authorized cleanup
+- `dependency-audit` for dependency checks in audit mode when evidence needs refresh
+- `test-runner` for focused verification of authorized repairs
+
+Resolve each engine through the active catalog and resources relative to its
+installed directory. Use Shipshit `deslop`; an upstream `pstack:deslop` plugin is
+a separate implementation, not an alias. Report missing engines instead of
+silently substituting a similarly named skill or installing dependencies.
+
+## Freeze the review scope
+
+Resolve the default branch and pin its fetched tip as END. Review all authors,
+including automation accounts. Use the requested branch only when explicitly
+selected. Resolve an explicit checkpoint as BASE and verify it is an ancestor of
+END. Report rewritten or unavailable history instead of silently resetting it.
+
+For a date window, record absolute start/end and timezone. Identify changes
+integrated into the target branch during that interval, including older authored
+commits merged during the week. Use integration/merge evidence rather than
+author dates alone. Include root-commit content when the window spans repository
+creation. Record the commit inventory and endpoints; disclose shallow or missing
+history. Inspect individual commit/PR diffs as needed because an aggregate diff
+can hide changes later reverted.
+
+Keep uncommitted work and open PRs separate from integrated history. In a monorepo,
+list affected applications, shared packages, and downstream consumers. Apply a
+package filter without dropping cross-package contracts or claiming whole-repo
+coverage. Record any limits before drawing conclusions.
+
+## Audit work and implementation
+
+Run the `board-sync` skill in report mode for the selected board and scope.
+Preserve its status semantics and incomplete-coverage findings. Audit every
+current in-scope issue, including backlog and deferred work; report archived
+history coverage separately. Inventory issues missing from the board as well as
+cards missing repository linkage.
+
+For each issue, compare the stated problem and acceptance criteria with current
+code, relevant tests, linked PRs, and deployment evidence where shipment matters.
+Run the `code-review` skill for a targeted diff/spec comparison when useful.
+Distinguish implemented, partial, still valid, superseded/duplicate, and unclear.
+Keep stale issue wording separate from a real code defect. Absence of a patch or
+a closed issue does not establish implementation or deployment.
+
+Return an issue coverage table with evidence and proposed disposition. Mark
+uninspected issues explicitly; a sample cannot support an all-issues verdict.
+Recommend closure or reprioritization only when evidence supports it.
+
+## Review the period
+
+Run the `code-review` skill over the frozen changes for correctness and spec
+fidelity before the broader retrospective. Run the `full-code-review` skill
+with the frozen BASE-to-END diff, changed files,
+and COMMIT_LOG. Request its retrospective backlog and cross-commit lens. Preserve
+the complete commit inventory, including changes absent from the final diff.
+Report per-commit coverage and any omitted hunks or packages.
+
+Combine new findings with the issue audit. Check existing issues and open PRs
+before proposing another repair. Trace findings to files, commits, and affected
+behavior. Keep a missing spec visible instead of inventing requirements.
+
+Read existing CI, security/dependency alerts, deployment, and monitoring reports
+for the same scope. Check recurring errors, failed jobs, flaky checks, rollbacks,
+and integrated changes awaiting deployment. Run `dependency-audit` in audit mode
+only when relevant evidence is stale or absent and execution is available on an
+allowed host. Report each unavailable source as unavailable, not healthy.
+Reserve a full security or architecture audit for evidence that warrants it.
+
+## Repair and deslop
+
+Run the `deslop` skill in dry-run mode over the explicitly frozen changed files
+and hunks. Pass that scope directly; its default branch-diff calculation may be
+empty after changes have merged. Review-only runs stop at findings.
+
+With repair authority, address confirmed defects before cleanup. Retain existing
+behavior during deslop; preserve meaningful checks, technical language, and
+product intent. Apply findings to current code in an isolated scoped branch,
+rechecking evidence when the branch has advanced. A weekly request does not
+authorize a whole-tree rewrite.
+
+Run the `test-runner` skill for affected verification, preserving host restrictions
+and the authorized repair scope. Use fresh CI and required review gates for
+publication and any separately authorized merge. Keep fixes isolated from
+unrelated work; failed checks remain unresolved findings.
+
+Re-read affected board evidence after repairs. Apply only separately authorized,
+provider-supported corrections through `board-sync`. Issue closure and Jira
+transitions remain distinct actions. Do not normalize board configuration merely
+to make the audit pass.
+
+## Close the review
+
+Deliver one concise report with evidence links:
+
+- **Scope and coverage:** repository/board, window, BASE/END, commit and issue
+  counts, packages, sources, and completed/unavailable/uninspected checks
+- **Shipped:** verified delivery; list merged-but-not-deployed work separately
+- **Broken, drifted, blocked:** prioritized findings with existing issue/PR links,
+  impact, evidence, and the proposed next action
+- **Repaired:** exact changes, verification, PRs, and remaining delivery gates
+- **Next priorities:** the three highest-value actions, or fewer when justified
+- **Checkpoint:** END only for completely reviewed code scope; retain the previous
+  checkpoint and exact remaining scope when review is partial. Track unresolved
+  findings and incomplete board/operational checks separately for the next run.
+
+An empty commit window still permits board and operational review. State no code
+changes rather than manufacturing cleanup. Finish report-only runs with the
+report. In repair mode, finish the authorized repair/delivery scope or identify
+the concrete remaining blocker. A recurring workflow does not itself schedule
+an automation.

--- a/bundles/dev-workflow/skills/weekly-review/plugin.json
+++ b/bundles/dev-workflow/skills/weekly-review/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "weekly-review",
+  "version": "1.0.0",
+  "description": "Weekly board, code, operations, and cleanup review with scoped repairs",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://shipshit.dev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/catalog.json
+++ b/catalog.json
@@ -7,10 +7,10 @@
     "layout": "git ls-files"
   },
   "counts": {
-    "skills": 186,
-    "commands": 29,
+    "skills": 187,
+    "commands": 30,
     "bundles": 13,
-    "plugins": 199
+    "plugins": 200
   },
   "bundles": [
     "ai-agents",

--- a/commands/weekly-review.md
+++ b/commands/weekly-review.md
@@ -14,7 +14,7 @@ Coordinate the recurring repository maintenance review through `weekly-review`.
 
 Pass the repository, board URL, optional package scope, window, and existing
 authorization to the `weekly-review` skill. Default to seven days and report-only.
-Preserve `--report-only` across every delegate. `--fix` authorizes scoped code
+Preserve `--report-only` across every delegate; it wins when both flags are supplied. `--fix` authorizes scoped code
 repairs; it does not authorize board writes, issue closure, merges, deployments,
 or a recurring schedule. Preserve separately granted authority without reasking.
 

--- a/commands/weekly-review.md
+++ b/commands/weekly-review.md
@@ -1,0 +1,22 @@
+# Weekly Review
+
+Coordinate the recurring repository maintenance review through `weekly-review`.
+
+## Usage
+
+```text
+/weekly-review
+/weekly-review 7d
+/weekly-review since <SHA>
+/weekly-review 14d --report-only
+/weekly-review 7d --fix
+```
+
+Pass the repository, board URL, optional package scope, window, and existing
+authorization to the `weekly-review` skill. Default to seven days and report-only.
+Preserve `--report-only` across every delegate. `--fix` authorizes scoped code
+repairs; it does not authorize board writes, issue closure, merges, deployments,
+or a recurring schedule. Preserve separately granted authority without reasking.
+
+Report unknown arguments and show usage. Resolve ambiguous targets before
+dependent work while continuing independent inspection.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "description": "186 AI agent skills for development workflows. Works with Claude Code, OpenAI Codex, and Cursor.",
+  "description": "187 AI agent skills for development workflows. Works with Claude Code, OpenAI Codex, and Cursor.",
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
     "husky": "9.1.7",

--- a/scripts/plugin-categories.json
+++ b/scripts/plugin-categories.json
@@ -227,9 +227,9 @@
         "systematic-debugging",
         "tech-debt",
         "verification-before-completion",
+        "weekly-review",
         "wizard",
-        "worktree",
-        "weekly-review"
+        "worktree"
       ]
     },
     "session": {

--- a/scripts/plugin-categories.json
+++ b/scripts/plugin-categories.json
@@ -228,7 +228,8 @@
         "tech-debt",
         "verification-before-completion",
         "wizard",
-        "worktree"
+        "worktree",
+        "weekly-review"
       ]
     },
     "session": {

--- a/skills/weekly-review/SKILL.md
+++ b/skills/weekly-review/SKILL.md
@@ -134,9 +134,12 @@ rechecking evidence when the branch has advanced. A weekly request does not
 authorize a whole-tree rewrite.
 
 Run the `test-runner` skill for affected verification, preserving host restrictions
-and the authorized repair scope. Use fresh CI and required review gates for
-publication and any separately authorized merge. Keep fixes isolated from
-unrelated work; failed checks remain unresolved findings.
+and the authorized repair scope. Satisfy repository-required local checks and
+review gates before publication. If the allowed verification host is unavailable,
+keep the repair unverified; do not substitute CI for required local checks.
+Follow the repository's policy for any draft PR. Use fresh CI and required review
+for a separately authorized merge. Report completed actions separately from
+planned actions. Failed checks remain unresolved findings.
 
 Re-read affected board evidence after repairs. Apply only separately authorized,
 provider-supported corrections through `board-sync`. Issue closure and Jira
@@ -155,7 +158,9 @@ Deliver one concise report with evidence links:
 - **Repaired:** exact changes, verification, PRs, and remaining delivery gates
 - **Next priorities:** the three highest-value actions, or fewer when justified
 - **Checkpoint:** END only for completely reviewed code scope; retain the previous
-  checkpoint and exact remaining scope when review is partial. Track unresolved
+  checkpoint and exact remaining scope when review is partial. Required cross-package
+  contract and consumer checks are part of that scope; an uninspected required
+  consumer prevents advancing the affected checkpoint. Track unresolved
   findings and incomplete board/operational checks separately for the next run.
 
 An empty commit window still permits board and operational review. State no code

--- a/skills/weekly-review/SKILL.md
+++ b/skills/weekly-review/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: weekly-review
+description: Coordinates a weekly engineering review of board accuracy, recent code changes, operational health, and scoped cleanup. Use for a recurring repository health review or a review of the last several days.
+compatibility: Requires repository history and access to the selected board; operational checks depend on existing service connections.
+metadata:
+  version: "1.0.0"
+  tags: "review, weekly, maintenance, boards, retrospective"
+  author: Ship Shit Dev
+---
+
+# Weekly Review
+
+Turn a review period into an evidence-backed maintenance report and, when
+requested, verified repairs. Reuse the review and cleanup engines. Keep provider
+procedures and review rubrics in their owning skills.
+
+## Contract
+
+Inputs:
+
+- Repository or monorepo, board URL/provider, and optional package scope
+- A window such as `7d` (default), explicit dates with timezone, or `since <SHA>`
+- Optional previous review checkpoint and explicitly authorized repair scope
+- Report-only by default; `--fix` authorizes code repairs for confirmed findings
+  within the reviewed scope; `--report-only` overrides earlier repair authority
+
+Outputs:
+
+- One report of shipped, broken, drifted, blocked, repaired, and next priorities
+- Evidence and coverage per repository, issue, package, and operational check
+- Reviewed commit endpoints and a proposed next checkpoint, with unfinished work
+
+Creates/Modifies:
+
+- Nothing in report-only mode; return the report and checkpoint in the response
+- In repair mode: scoped source/test edits and verification artifacts; publish
+  repair PRs according to the repository's existing delivery policy
+
+External Side Effects:
+
+- Reads repository, board, CI, deployment, and available monitoring evidence
+- Board edits, issue filing/closure, comments, merges, deployments, installations,
+  and scheduling require their own explicit scope; `--fix` grants none of these
+
+Confirmation Required:
+
+- Only for missing or expanded authority; preserve existing explicit approval
+  for the same target/actions and forward restrictions to every delegate
+- Review requests and findings are not permission to modify production
+
+Delegates To:
+
+- `board-sync` for board reconciliation and approved supported field corrections
+- `full-code-review` for retrospective review using the frozen diff and commit log
+- `code-review` for correctness and implementation-versus-acceptance checks
+- `deslop` for scoped dry-run findings or authorized cleanup
+- `dependency-audit` for dependency checks in audit mode when evidence needs refresh
+- `test-runner` for focused verification of authorized repairs
+
+Resolve each engine through the active catalog and resources relative to its
+installed directory. Use Shipshit `deslop`; an upstream `pstack:deslop` plugin is
+a separate implementation, not an alias. Report missing engines instead of
+silently substituting a similarly named skill or installing dependencies.
+
+## Freeze the review scope
+
+Resolve the default branch and pin its fetched tip as END. Review all authors,
+including automation accounts. Use the requested branch only when explicitly
+selected. Resolve an explicit checkpoint as BASE and verify it is an ancestor of
+END. Report rewritten or unavailable history instead of silently resetting it.
+
+For a date window, record absolute start/end and timezone. Identify changes
+integrated into the target branch during that interval, including older authored
+commits merged during the week. Use integration/merge evidence rather than
+author dates alone. Include root-commit content when the window spans repository
+creation. Record the commit inventory and endpoints; disclose shallow or missing
+history. Inspect individual commit/PR diffs as needed because an aggregate diff
+can hide changes later reverted.
+
+Keep uncommitted work and open PRs separate from integrated history. In a monorepo,
+list affected applications, shared packages, and downstream consumers. Apply a
+package filter without dropping cross-package contracts or claiming whole-repo
+coverage. Record any limits before drawing conclusions.
+
+## Audit work and implementation
+
+Run the `board-sync` skill in report mode for the selected board and scope.
+Preserve its status semantics and incomplete-coverage findings. Audit every
+current in-scope issue, including backlog and deferred work; report archived
+history coverage separately. Inventory issues missing from the board as well as
+cards missing repository linkage.
+
+For each issue, compare the stated problem and acceptance criteria with current
+code, relevant tests, linked PRs, and deployment evidence where shipment matters.
+Run the `code-review` skill for a targeted diff/spec comparison when useful.
+Distinguish implemented, partial, still valid, superseded/duplicate, and unclear.
+Keep stale issue wording separate from a real code defect. Absence of a patch or
+a closed issue does not establish implementation or deployment.
+
+Return an issue coverage table with evidence and proposed disposition. Mark
+uninspected issues explicitly; a sample cannot support an all-issues verdict.
+Recommend closure or reprioritization only when evidence supports it.
+
+## Review the period
+
+Run the `code-review` skill over the frozen changes for correctness and spec
+fidelity before the broader retrospective. Run the `full-code-review` skill
+with the frozen BASE-to-END diff, changed files,
+and COMMIT_LOG. Request its retrospective backlog and cross-commit lens. Preserve
+the complete commit inventory, including changes absent from the final diff.
+Report per-commit coverage and any omitted hunks or packages.
+
+Combine new findings with the issue audit. Check existing issues and open PRs
+before proposing another repair. Trace findings to files, commits, and affected
+behavior. Keep a missing spec visible instead of inventing requirements.
+
+Read existing CI, security/dependency alerts, deployment, and monitoring reports
+for the same scope. Check recurring errors, failed jobs, flaky checks, rollbacks,
+and integrated changes awaiting deployment. Run `dependency-audit` in audit mode
+only when relevant evidence is stale or absent and execution is available on an
+allowed host. Report each unavailable source as unavailable, not healthy.
+Reserve a full security or architecture audit for evidence that warrants it.
+
+## Repair and deslop
+
+Run the `deslop` skill in dry-run mode over the explicitly frozen changed files
+and hunks. Pass that scope directly; its default branch-diff calculation may be
+empty after changes have merged. Review-only runs stop at findings.
+
+With repair authority, address confirmed defects before cleanup. Retain existing
+behavior during deslop; preserve meaningful checks, technical language, and
+product intent. Apply findings to current code in an isolated scoped branch,
+rechecking evidence when the branch has advanced. A weekly request does not
+authorize a whole-tree rewrite.
+
+Run the `test-runner` skill for affected verification, preserving host restrictions
+and the authorized repair scope. Use fresh CI and required review gates for
+publication and any separately authorized merge. Keep fixes isolated from
+unrelated work; failed checks remain unresolved findings.
+
+Re-read affected board evidence after repairs. Apply only separately authorized,
+provider-supported corrections through `board-sync`. Issue closure and Jira
+transitions remain distinct actions. Do not normalize board configuration merely
+to make the audit pass.
+
+## Close the review
+
+Deliver one concise report with evidence links:
+
+- **Scope and coverage:** repository/board, window, BASE/END, commit and issue
+  counts, packages, sources, and completed/unavailable/uninspected checks
+- **Shipped:** verified delivery; list merged-but-not-deployed work separately
+- **Broken, drifted, blocked:** prioritized findings with existing issue/PR links,
+  impact, evidence, and the proposed next action
+- **Repaired:** exact changes, verification, PRs, and remaining delivery gates
+- **Next priorities:** the three highest-value actions, or fewer when justified
+- **Checkpoint:** END only for completely reviewed code scope; retain the previous
+  checkpoint and exact remaining scope when review is partial. Track unresolved
+  findings and incomplete board/operational checks separately for the next run.
+
+An empty commit window still permits board and operational review. State no code
+changes rather than manufacturing cleanup. Finish report-only runs with the
+report. In repair mode, finish the authorized repair/delivery scope or identify
+the concrete remaining blocker. A recurring workflow does not itself schedule
+an automation.

--- a/skills/weekly-review/plugin.json
+++ b/skills/weekly-review/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "weekly-review",
+  "version": "1.0.0",
+  "description": "Weekly board, code, operations, and cleanup review with scoped repairs",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://shipshit.dev"
+  },
+  "license": "MIT",
+  "skills": "."
+}


### PR DESCRIPTION
The weekly maintenance review previously required manually coordinating board reconciliation, issue acceptance checks, historical review, operational evidence, and deslop. Add `weekly-review` and `/weekly-review` to produce one evidence-backed report and carry explicitly scoped repair authority through the existing engines.

The coordinator freezes branch endpoints, includes all authors and integration-time evidence, checks issue claims against implementation, distinguishes merged work from deployment, and retains incomplete coverage before proposing a checkpoint. It deduplicates repairs against existing issues/PRs and selects Shipshit deslop explicitly. Report-only remains the default; code-fix scope does not grant board writes, issue closure, merges, deployments, or scheduling.

Published through the existing generated dev-workflow bundle and individual plugin catalog. Catalog now contains 187 skills, 30 commands, 13 bundles, and 200 plugins.

Validation on Mac Studio: full lint passed; skill validation found zero errors and one pre-existing compatibility warning; 48 repository regression tests passed; the official skills CLI installed the coordinator and six companion engines into an isolated consumer layout, with canonical content equality and the installed board helper help invocation verified. Generated catalog/bundles are current. Independent Claude review PASS on final source head 3d90c0bb1b878de5d6ffa8e4e7fc013dcc2ed1dc (session 00727002-60ec-476c-a9ad-b32e979a1f4e), including six scenario packets examined as document review. Required CI passed in run 33952718641. Scenario execution on the Studio was unavailable because its Claude account is not signed in; no executed behavioral evaluation is claimed. No live board mutations or end-to-end weekly audit claimed.

Closes #138.
